### PR TITLE
[HEX-63] feat: add radio frequency fields, FrequencyService, and FrequenciesController

### DIFF
--- a/CODING-STANDARDS.md
+++ b/CODING-STANDARDS.md
@@ -1,0 +1,263 @@
+# CODING-STANDARDS.md
+
+Standards for the milsim-planning codebase. Every developer agent reads this before writing any code. The Architect references this when writing API contracts. The Code Reviewer checks against this.
+
+---
+
+## Identity & Primary Keys
+
+- **All primary keys are `Guid`** — never `int`, never `string`
+- **Route constraints must be typed:** `[HttpGet("{eventId:guid}")]` not `[HttpGet("{eventId}")]`
+- **TypeScript represents Guids as `string`** (UUID format: `"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`)
+- **Never pass string literals as IDs** — if it's an entity ID, it's a Guid on the backend and a UUID-format string on the frontend
+
+```csharp
+// ✅ Correct
+[HttpGet("{factionId:guid}/frequencies")]
+public async Task<IActionResult> GetFrequencies(Guid factionId)
+
+// ❌ Wrong
+[HttpGet("{factionId}/frequencies")]
+public async Task<IActionResult> GetFrequencies(string factionId)
+```
+
+```typescript
+// ✅ Correct — Guid arrives as UUID string from API
+const factionId: string = faction.id; // "a1b2c3d4-..."
+
+// ❌ Wrong — never use arbitrary string as ID
+const factionId = "faction"; // hard-coded string is not an ID
+```
+
+---
+
+## API Routes
+
+- **Pattern:** `/api/{resource}/{id:guid}/{sub-resource}`
+- **HTTP verbs:** GET (read), POST (create), PUT (full replace), PATCH (partial update), DELETE
+- **Routes are plural nouns:** `/api/events` not `/api/event`
+- **Sub-resources follow the parent:** `/api/events/{eventId:guid}/frequencies`
+- **Routes must match the contract exactly** — copy verbatim from the sequence diagram/API contract
+
+```csharp
+// ✅ Correct route pattern
+[Route("api/events/{eventId:guid}/frequencies")]
+[HttpGet]
+public async Task<ActionResult<FrequencyDto>> GetFrequencies(Guid eventId)
+
+// ❌ Wrong — missing plural, missing type constraint
+[HttpGet("api/event/{eventId}/frequency")]
+```
+
+---
+
+## DTOs and Request/Response Models
+
+- **Response DTO naming:** `{Feature}Dto` — e.g., `FrequencyDto`, `EventDto`, `PlayerDto`
+- **Request model naming:** `{Action}{Feature}Request` — e.g., `UpdateFrequencyRequest`, `CreateEventRequest`
+- **Never return entity objects directly** — always map to a DTO
+- **Nullable fields use `?`:** `string? PrimaryFrequency` not `string PrimaryFrequency`
+- **All IDs in DTOs are `Guid`** — consistent with entities
+
+```csharp
+// ✅ Correct DTO
+public class FrequencyDto
+{
+    public Guid FactionId { get; set; }
+    public string? CommandPrimary { get; set; }
+    public string? CommandBackup { get; set; }
+}
+
+// ❌ Wrong — using string ID, returning raw entity fields
+public class FrequencyResponse
+{
+    public string factionId { get; set; } // wrong type + wrong casing
+}
+```
+
+```typescript
+// ✅ Correct TypeScript interface matching DTO
+interface FrequencyDto {
+  factionId: string;          // Guid as UUID string
+  commandPrimary: string | null;
+  commandBackup: string | null;
+}
+```
+
+---
+
+## Error Response Shapes
+
+**All API errors follow a standard shape.** Developers must implement this shape. Code Reviewer must verify it. Architect must reference it in contracts — no "returns 403", always "returns 403 with `ProblemDetails`".
+
+### Standard error shape (ASP.NET Core ProblemDetails)
+
+```csharp
+// ✅ Use ProblemDetails for all error responses
+return Problem(
+    title: "Forbidden",
+    detail: "Insufficient role to access this resource.",
+    statusCode: 403
+);
+```
+
+```json
+// ✅ What the client receives
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Insufficient role to access this resource."
+}
+```
+
+### Standard error codes and their shapes
+
+| Status | When | `title` | `detail` |
+|--------|------|---------|---------|
+| 400 | Invalid input | "Bad Request" | Specific validation message |
+| 401 | No/expired token | "Unauthorized" | "Authentication required." |
+| 403 | Wrong role / IDOR | "Forbidden" | "Insufficient role to access this resource." |
+| 404 | Entity not found | "Not Found" | "[Entity] {id} not found." |
+| 409 | Conflict | "Conflict" | Specific conflict message |
+
+### In API contracts
+Every endpoint in the Architect's plan must specify errors as:
+```
+- 403: { status: 403, title: "Forbidden", detail: "Insufficient role..." }
+- 404: { status: 404, title: "Not Found", detail: "[Entity] {id} not found." }
+```
+Not just `→ 403`. Always the full shape.
+
+---
+
+## Test Naming and Structure
+
+- **Test class naming:** `{Feature}Tests` — e.g., `FrequencyTests`, `HierarchyTests`
+- **Test method naming:** `{Feature}_{Scenario}_{ExpectedResult}`
+  - e.g., `GetFrequencies_AsSquadMember_ReturnsOnlySquadFrequency`
+  - e.g., `UpdateFrequency_AsNonCommander_Returns403`
+- **Every endpoint must have integration tests** — no exceptions
+- **Tests use real PostgreSQL via Testcontainers** — no mocked databases
+- **Test coverage required:**
+  - Happy path for every endpoint
+  - Authorization: assert the right roles can/cannot access
+  - IDOR: assert users cannot access other events' data
+  - Edge cases: null/empty inputs, non-existent IDs
+
+```csharp
+// ✅ Correct test method name
+[Fact]
+public async Task GetFrequencies_AsSquadMember_ReturnsOnlySquadFrequency()
+
+// ❌ Wrong — vague name, unclear what's being tested
+[Fact]
+public async Task TestFrequencies()
+```
+
+---
+
+## Entity and Migration Rules
+
+- **Entity properties added to migration must also be added to entity class** — always both, never just one
+- **Migrations are delta-based** — never drop-and-recreate, always additive
+- **Nullable columns use `string?` in entities** — not empty string defaults
+- **Every entity has a `Guid Id` primary key**
+
+```csharp
+// ✅ Correct — entity class updated to match migration
+public class Squad
+{
+    public Guid Id { get; set; }
+    public string? SquadPrimaryFrequency { get; set; }  // added with migration
+    public string? SquadBackupFrequency { get; set; }   // added with migration
+}
+
+// ❌ Wrong — migration added columns but entity class not updated
+public class Squad
+{
+    public Guid Id { get; set; }
+    // frequency columns missing — compile error in FrequencyService
+}
+```
+
+---
+
+## Service Layer Rules
+
+- **No N+1 queries** — always use `.Include()` for related entities, never query inside a loop
+- **Services throw exceptions; controllers catch them:**
+  - `KeyNotFoundException` → 404
+  - `ArgumentException` → 400
+  - `ForbiddenException` → 403
+  - `InvalidOperationException` → 409
+- **ScopeGuard.AssertEventAccess first** — before any business logic in service methods
+- **No raw SQL** — always EF Core
+
+```csharp
+// ✅ Correct — Include to avoid N+1
+var squads = await _db.Squads
+    .Include(s => s.Players)
+    .Where(s => s.PlatoonId == platoonId)
+    .ToListAsync();
+
+// ❌ Wrong — N+1 query
+var squads = await _db.Squads.Where(s => s.PlatoonId == platoonId).ToListAsync();
+foreach (var squad in squads)
+{
+    squad.Players = await _db.Players.Where(p => p.SquadId == squad.Id).ToListAsync();
+}
+```
+
+---
+
+## Frontend Rules
+
+- **All API calls go through `lib/api.ts`** — never `fetch()` directly in components
+- **Server state uses TanStack Query** — no manual useState + useEffect for API data
+- **Hook naming:** `use{Feature}` returning `{ data, isLoading, error, refetch }`
+- **Component files are PascalCase:** `FrequencyDisplay.tsx` not `frequency-display.tsx`
+- **Zero console errors** before declaring done — DevTools Console must be clean
+- **No `any` types** — TypeScript strict mode, explicit types everywhere
+
+```typescript
+// ✅ Correct hook pattern
+export function useFrequencies(eventId: string) {
+  return useQuery({
+    queryKey: ['frequencies', eventId],
+    queryFn: () => getFrequencies(eventId),
+  });
+}
+
+// ❌ Wrong — manual fetch in component
+const [data, setData] = useState(null);
+useEffect(() => {
+  fetch('/api/frequencies').then(r => r.json()).then(setData);
+}, []);
+```
+
+---
+
+## Git Commit Standards
+
+- **Every task gets a commit** before marking done
+- **Commit message format:** `[HEX-X] {type}: {description}`
+  - Types: `feat`, `fix`, `test`, `refactor`, `docs`, `chore`
+  - e.g., `[HEX-14] feat: add radio frequency fields to Squad, Platoon, Faction entities`
+- **Commit after each logical unit** — backend commit, then frontend commit
+- **Include the issue identifier** in every commit message
+
+---
+
+## Pre-Implementation Verification
+
+Before writing any code, answer these questions:
+
+1. **IDs:** Are all entity IDs `Guid`? Do my route constraints use `:guid`?
+2. **Routes:** Did I copy the routes verbatim from the API contract?
+3. **DTOs:** Do my DTO field names and types match the API contract exactly?
+4. **Tests:** Does my file manifest include a test file? What test cases will I write?
+5. **Entity + Migration:** If I'm adding a column, am I updating both the migration AND the entity class?
+6. **N+1:** Am I querying inside any loops? If yes, convert to `.Include()`.
+
+If any answer is "no" or "unsure" — resolve before writing code.

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/Frequencies/FrequencyTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/Frequencies/FrequencyTests.cs
@@ -1,0 +1,497 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Services;
+using MilsimPlanning.Api.Tests.Fixtures;
+using Moq;
+using Xunit;
+
+namespace MilsimPlanning.Api.Tests.Frequencies;
+
+public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+{
+    protected readonly PostgreSqlFixture _fixture;
+    protected WebApplicationFactory<Program> _factory = null!;
+    protected Mock<IEmailService> _emailMock = null!;
+
+    // Clients
+    protected HttpClient _commanderClient = null!;
+    protected HttpClient _playerClient = null!;
+    protected HttpClient _squadLeaderClient = null!;
+    protected HttpClient _platoonLeaderClient = null!;
+    protected HttpClient _outsiderClient = null!;
+    protected HttpClient _unauthenticatedClient = null!;
+
+    // IDs
+    protected Guid _eventId;
+    protected Guid _otherEventId;
+    protected Guid _squadId;
+    protected Guid _platoonId;
+    protected Guid _factionId;
+
+    // User IDs
+    protected string _commanderUserId = string.Empty;
+    protected string _playerUserId = string.Empty;
+    protected string _squadLeaderUserId = string.Empty;
+    protected string _platoonLeaderUserId = string.Empty;
+    protected string _outsiderUserId = string.Empty;
+
+    public FrequencyTestsBase(PostgreSqlFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        _emailMock = new Mock<IEmailService>();
+        _emailMock.Setup(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(Task.CompletedTask);
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Jwt:Secret"]   = "dev-placeholder-secret-32-chars!!",
+                        ["Jwt:Issuer"]   = "milsim-tests",
+                        ["Jwt:Audience"] = "milsim-tests"
+                    });
+                });
+
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<DbContextOptions<AppDbContext>>();
+                    services.RemoveAll<AppDbContext>();
+                    services.AddDbContext<AppDbContext>(opts =>
+                        opts.UseNpgsql(_fixture.ConnectionString));
+
+                    services.RemoveAll<IEmailService>();
+                    services.AddSingleton(_emailMock.Object);
+
+                    services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = IntegrationTestAuthHandler.SchemeName;
+                        options.DefaultChallengeScheme    = IntegrationTestAuthHandler.SchemeName;
+                    }).AddScheme<AuthenticationSchemeOptions, IntegrationTestAuthHandler>(
+                        IntegrationTestAuthHandler.SchemeName, _ => { });
+                });
+            });
+
+        using var scope = _factory.Services.CreateScope();
+        var db          = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.MigrateAsync();
+
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        foreach (var role in new[] { "player", "squad_leader", "platoon_leader", "faction_commander", "system_admin" })
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+                await roleManager.CreateAsync(new IdentityRole(role));
+        }
+
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+
+        // Commander
+        var commanderEmail = $"freq-cmdr-{Guid.NewGuid():N}@test.com";
+        var commander = new AppUser { UserName = commanderEmail, Email = commanderEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(commander, "TestPass123!");
+        await userManager.AddToRoleAsync(commander, "faction_commander");
+        commander.Profile = new UserProfile { UserId = commander.Id, Callsign = "Commander", DisplayName = "Commander", User = commander };
+        _commanderUserId = commander.Id;
+
+        // Player
+        var playerEmail = $"freq-player-{Guid.NewGuid():N}@test.com";
+        var player = new AppUser { UserName = playerEmail, Email = playerEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(player, "TestPass123!");
+        await userManager.AddToRoleAsync(player, "player");
+        player.Profile = new UserProfile { UserId = player.Id, Callsign = "Player1", DisplayName = "Player1", User = player };
+        _playerUserId = player.Id;
+
+        // Squad leader
+        var slEmail = $"freq-sl-{Guid.NewGuid():N}@test.com";
+        var squadLeader = new AppUser { UserName = slEmail, Email = slEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(squadLeader, "TestPass123!");
+        await userManager.AddToRoleAsync(squadLeader, "squad_leader");
+        squadLeader.Profile = new UserProfile { UserId = squadLeader.Id, Callsign = "SL1", DisplayName = "SL1", User = squadLeader };
+        _squadLeaderUserId = squadLeader.Id;
+
+        // Platoon leader
+        var plEmail = $"freq-pl-{Guid.NewGuid():N}@test.com";
+        var platoonLeader = new AppUser { UserName = plEmail, Email = plEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(platoonLeader, "TestPass123!");
+        await userManager.AddToRoleAsync(platoonLeader, "platoon_leader");
+        platoonLeader.Profile = new UserProfile { UserId = platoonLeader.Id, Callsign = "PL1", DisplayName = "PL1", User = platoonLeader };
+        _platoonLeaderUserId = platoonLeader.Id;
+
+        // Outsider (not a member of the event)
+        var outsiderEmail = $"freq-outsider-{Guid.NewGuid():N}@test.com";
+        var outsider = new AppUser { UserName = outsiderEmail, Email = outsiderEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(outsider, "TestPass123!");
+        await userManager.AddToRoleAsync(outsider, "player");
+        outsider.Profile = new UserProfile { UserId = outsider.Id, Callsign = "Outsider", DisplayName = "Outsider", User = outsider };
+        _outsiderUserId = outsider.Id;
+
+        // Seed primary event + faction hierarchy
+        _eventId   = Guid.NewGuid();
+        _factionId = Guid.NewGuid();
+
+        var faction = new Faction
+        {
+            Id          = _factionId,
+            Name        = "Test Faction",
+            CommanderId = commander.Id,
+            EventId     = _eventId
+        };
+        var testEvent = new Event
+        {
+            Id       = _eventId,
+            Name     = "Freq Test Event",
+            Status   = EventStatus.Draft,
+            FactionId = _factionId,
+            Faction  = faction
+        };
+        db.Events.Add(testEvent);
+
+        // Platoon + Squad
+        var platoon = new Platoon { FactionId = _factionId, Name = "Alpha Platoon", Order = 1 };
+        db.Platoons.Add(platoon);
+        await db.SaveChangesAsync();
+        _platoonId = platoon.Id;
+
+        var squad = new Squad { PlatoonId = platoon.Id, Name = "Alpha-1", Order = 1 };
+        db.Squads.Add(squad);
+        await db.SaveChangesAsync();
+        _squadId = squad.Id;
+
+        // EventMemberships
+        db.EventMemberships.Add(new EventMembership { UserId = commander.Id,     EventId = _eventId, Role = "faction_commander" });
+        db.EventMemberships.Add(new EventMembership { UserId = player.Id,        EventId = _eventId, Role = "player" });
+        db.EventMemberships.Add(new EventMembership { UserId = squadLeader.Id,   EventId = _eventId, Role = "squad_leader" });
+        db.EventMemberships.Add(new EventMembership { UserId = platoonLeader.Id, EventId = _eventId, Role = "platoon_leader" });
+
+        // EventPlayers (linked to users, assigned to positions)
+        var playerEp = new EventPlayer
+        {
+            EventId  = _eventId,
+            Email    = playerEmail.ToLowerInvariant(),
+            Name     = "Test Player",
+            UserId   = player.Id,
+            SquadId  = squad.Id,
+            PlatoonId = platoon.Id
+        };
+        var slEp = new EventPlayer
+        {
+            EventId   = _eventId,
+            Email     = slEmail.ToLowerInvariant(),
+            Name      = "Squad Leader",
+            UserId    = squadLeader.Id,
+            SquadId   = squad.Id,
+            PlatoonId = platoon.Id
+        };
+        var plEp = new EventPlayer
+        {
+            EventId   = _eventId,
+            Email     = plEmail.ToLowerInvariant(),
+            Name      = "Platoon Leader",
+            UserId    = platoonLeader.Id,
+            PlatoonId = platoon.Id
+        };
+        db.EventPlayers.AddRange(playerEp, slEp, plEp);
+
+        // Second event (for IDOR tests)
+        _otherEventId = Guid.NewGuid();
+        var otherFactionId = Guid.NewGuid();
+        var otherFaction = new Faction { Id = otherFactionId, Name = "Other Faction", CommanderId = commander.Id, EventId = _otherEventId };
+        var otherEvent = new Event { Id = _otherEventId, Name = "Other Event", Status = EventStatus.Draft, FactionId = otherFactionId, Faction = otherFaction };
+        db.Events.Add(otherEvent);
+        db.EventMemberships.Add(new EventMembership { UserId = commander.Id, EventId = _otherEventId, Role = "faction_commander" });
+
+        await db.SaveChangesAsync();
+
+        // Create clients
+        _commanderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_commanderClient, commander.Id, "faction_commander");
+
+        _playerClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_playerClient, player.Id, "player");
+
+        _squadLeaderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_squadLeaderClient, squadLeader.Id, "squad_leader");
+
+        _platoonLeaderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_platoonLeaderClient, platoonLeader.Id, "platoon_leader");
+
+        _outsiderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_outsiderClient, outsider.Id, "player");
+
+        _unauthenticatedClient = _factory.CreateClient();
+    }
+
+    public Task DisposeAsync()
+    {
+        _commanderClient.Dispose();
+        _playerClient.Dispose();
+        _squadLeaderClient.Dispose();
+        _platoonLeaderClient.Dispose();
+        _outsiderClient.Dispose();
+        _unauthenticatedClient.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    protected AppDbContext GetDb()
+    {
+        var scope = _factory.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    }
+}
+
+// ── GET /api/events/{eventId}/frequencies ─────────────────────────────────────
+
+[Trait("Category", "Frequency_Get")]
+public class FrequencyGetTests : FrequencyTestsBase
+{
+    public FrequencyGetTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task GetFrequencies_AsPlayer_ReturnsOnlySquadFrequency()
+    {
+        // Seed a squad frequency so we can assert it comes back
+        using var db = GetDb();
+        var squad = await db.Squads.FindAsync(_squadId);
+        squad!.SquadPrimaryFrequency = "34.500";
+        squad.SquadBackupFrequency   = "35.000";
+        await db.SaveChangesAsync();
+
+        var response = await _playerClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("squad").GetProperty("primary").GetString().Should().Be("34.500");
+        body.GetProperty("squad").GetProperty("backup").GetString().Should().Be("35.000");
+        body.GetProperty("platoon").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("command").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GetFrequencies_AsSquadLeader_ReturnsSquadAndPlatoonFrequencies()
+    {
+        using var db = GetDb();
+        var squad   = await db.Squads.FindAsync(_squadId);
+        squad!.SquadPrimaryFrequency = "36.000";
+        var platoon = await db.Platoons.FindAsync(_platoonId);
+        platoon!.PlatoonPrimaryFrequency = "40.000";
+        await db.SaveChangesAsync();
+
+        var response = await _squadLeaderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("squad").GetProperty("primary").GetString().Should().Be("36.000");
+        body.GetProperty("platoon").GetProperty("primary").GetString().Should().Be("40.000");
+        body.GetProperty("command").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GetFrequencies_AsPlatoonLeader_ReturnsPlatoonAndCommandFrequencies()
+    {
+        using var db = GetDb();
+        var platoon = await db.Platoons.FindAsync(_platoonId);
+        platoon!.PlatoonPrimaryFrequency = "41.000";
+        var faction = await db.Factions.FindAsync(_factionId);
+        faction!.CommandPrimaryFrequency = "50.000";
+        await db.SaveChangesAsync();
+
+        var response = await _platoonLeaderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("squad").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("platoon").GetProperty("primary").GetString().Should().Be("41.000");
+        body.GetProperty("command").GetProperty("primary").GetString().Should().Be("50.000");
+    }
+
+    [Fact]
+    public async Task GetFrequencies_AsFactionCommander_ReturnsCommandFrequencyOnly()
+    {
+        using var db = GetDb();
+        var faction = await db.Factions.FindAsync(_factionId);
+        faction!.CommandPrimaryFrequency = "51.000";
+        faction.CommandBackupFrequency   = "52.000";
+        await db.SaveChangesAsync();
+
+        var response = await _commanderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("squad").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("platoon").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("command").GetProperty("primary").GetString().Should().Be("51.000");
+        body.GetProperty("command").GetProperty("backup").GetString().Should().Be("52.000");
+    }
+
+    [Fact]
+    public async Task GetFrequencies_WhenNotEventMember_Returns403()
+    {
+        var response = await _outsiderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetFrequencies_WhenPlayerNotYetAssigned_ReturnsNullSquadFrequency()
+    {
+        // Create a player that has no squad assigned
+        using var db = GetDb();
+        var unassignedEmail = $"unassigned-{Guid.NewGuid():N}@test.com";
+        var unassignedEp = new EventPlayer
+        {
+            EventId = _eventId,
+            Email   = unassignedEmail,
+            Name    = "Unassigned Player",
+            UserId  = _playerUserId   // reuse player userId but with no squad/platoon
+        };
+        // Remove existing player ep first so we don't clash on UserId
+        var existingEp = await db.EventPlayers.FirstOrDefaultAsync(ep => ep.UserId == _playerUserId && ep.EventId == _eventId);
+        if (existingEp != null)
+        {
+            existingEp.SquadId   = null;
+            existingEp.PlatoonId = null;
+            await db.SaveChangesAsync();
+        }
+
+        var response = await _playerClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        // Squad exists in DTO but primary/backup are null since no squad assigned
+        body.GetProperty("squad").GetProperty("primary").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("platoon").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("command").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GetFrequencies_Unauthenticated_Returns401()
+    {
+        var response = await _unauthenticatedClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}
+
+// ── PUT squad frequencies ─────────────────────────────────────────────────────
+
+[Trait("Category", "Frequency_UpdateSquad")]
+public class UpdateSquadFrequencyTests : FrequencyTestsBase
+{
+    public UpdateSquadFrequencyTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task UpdateSquadFrequency_AsFactionCommander_Succeeds()
+    {
+        var response = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/squads/{_squadId}/frequencies",
+            new { primary = "37.500", backup = "38.000" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("primary").GetString().Should().Be("37.500");
+        body.GetProperty("backup").GetString().Should().Be("38.000");
+
+        using var db = GetDb();
+        var squad = await db.Squads.FindAsync(_squadId);
+        squad!.SquadPrimaryFrequency.Should().Be("37.500");
+        squad.SquadBackupFrequency.Should().Be("38.000");
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequency_AsNonCommander_Returns403()
+    {
+        var response = await _playerClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/squads/{_squadId}/frequencies",
+            new { primary = "37.500" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequency_WithSquadFromDifferentEvent_Returns403()
+    {
+        // _squadId belongs to _eventId; try to set it via _otherEventId
+        var response = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_otherEventId}/squads/{_squadId}/frequencies",
+            new { primary = "99.999" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}
+
+// ── PUT platoon frequencies ───────────────────────────────────────────────────
+
+[Trait("Category", "Frequency_UpdatePlatoon")]
+public class UpdatePlatoonFrequencyTests : FrequencyTestsBase
+{
+    public UpdatePlatoonFrequencyTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task UpdatePlatoonFrequency_AsFactionCommander_Succeeds()
+    {
+        var response = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/platoons/{_platoonId}/frequencies",
+            new { primary = "42.000", backup = "43.000" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("primary").GetString().Should().Be("42.000");
+        body.GetProperty("backup").GetString().Should().Be("43.000");
+
+        using var db = GetDb();
+        var platoon = await db.Platoons.FindAsync(_platoonId);
+        platoon!.PlatoonPrimaryFrequency.Should().Be("42.000");
+        platoon.PlatoonBackupFrequency.Should().Be("43.000");
+    }
+
+    [Fact]
+    public async Task UpdatePlatoonFrequency_AsNonCommander_Returns403()
+    {
+        var response = await _playerClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/platoons/{_platoonId}/frequencies",
+            new { primary = "42.000" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}
+
+// ── PUT command frequencies ───────────────────────────────────────────────────
+
+[Trait("Category", "Frequency_UpdateCommand")]
+public class UpdateCommandFrequencyTests : FrequencyTestsBase
+{
+    public UpdateCommandFrequencyTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task UpdateCommandFrequency_AsFactionCommander_Succeeds()
+    {
+        var response = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/command-frequencies",
+            new { primary = "53.000", backup = "54.000" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("primary").GetString().Should().Be("53.000");
+        body.GetProperty("backup").GetString().Should().Be("54.000");
+
+        using var db = GetDb();
+        var faction = await db.Factions.FirstAsync(f => f.EventId == _eventId);
+        faction.CommandPrimaryFrequency.Should().Be("53.000");
+        faction.CommandBackupFrequency.Should().Be("54.000");
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequenciesController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequenciesController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Models.Frequencies;
+using MilsimPlanning.Api.Services;
+
+namespace MilsimPlanning.Api.Controllers;
+
+[ApiController]
+[Route("api/events/{eventId:guid}")]
+public class FrequenciesController : ControllerBase
+{
+    private readonly FrequencyService _frequencyService;
+
+    public FrequenciesController(FrequencyService frequencyService)
+        => _frequencyService = frequencyService;
+
+    [HttpGet("frequencies")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<FrequencyDto>> GetFrequencies(Guid eventId)
+    {
+        try
+        {
+            var dto = await _frequencyService.GetFrequenciesAsync(eventId);
+            return Ok(dto);
+        }
+        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
+        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+    }
+
+    [HttpPut("squads/{squadId:guid}/frequencies")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<FrequencyLevelDto>> UpdateSquadFrequency(
+        Guid eventId, Guid squadId, [FromBody] UpdateFrequencyRequest request)
+    {
+        try
+        {
+            var dto = await _frequencyService.UpdateSquadFrequencyAsync(eventId, squadId, request.Primary, request.Backup);
+            return Ok(dto);
+        }
+        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
+        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+    }
+
+    [HttpPut("platoons/{platoonId:guid}/frequencies")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<FrequencyLevelDto>> UpdatePlatoonFrequency(
+        Guid eventId, Guid platoonId, [FromBody] UpdateFrequencyRequest request)
+    {
+        try
+        {
+            var dto = await _frequencyService.UpdatePlatoonFrequencyAsync(eventId, platoonId, request.Primary, request.Backup);
+            return Ok(dto);
+        }
+        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
+        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+    }
+
+    [HttpPut("command-frequencies")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<FrequencyLevelDto>> UpdateCommandFrequency(
+        Guid eventId, [FromBody] UpdateFrequencyRequest request)
+    {
+        try
+        {
+            var dto = await _frequencyService.UpdateCommandFrequencyAsync(eventId, request.Primary, request.Backup);
+            return Ok(dto);
+        }
+        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
+        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequenciesController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequenciesController.cs
@@ -24,8 +24,8 @@ public class FrequenciesController : ControllerBase
             var dto = await _frequencyService.GetFrequenciesAsync(eventId);
             return Ok(dto);
         }
-        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
-        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found",  detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex)   { return Problem(title: "Forbidden",  detail: ex.Message, statusCode: 403); }
     }
 
     [HttpPut("squads/{squadId:guid}/frequencies")]
@@ -38,8 +38,8 @@ public class FrequenciesController : ControllerBase
             var dto = await _frequencyService.UpdateSquadFrequencyAsync(eventId, squadId, request.Primary, request.Backup);
             return Ok(dto);
         }
-        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
-        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found",  detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex)   { return Problem(title: "Forbidden",  detail: ex.Message, statusCode: 403); }
     }
 
     [HttpPut("platoons/{platoonId:guid}/frequencies")]
@@ -52,8 +52,8 @@ public class FrequenciesController : ControllerBase
             var dto = await _frequencyService.UpdatePlatoonFrequencyAsync(eventId, platoonId, request.Primary, request.Backup);
             return Ok(dto);
         }
-        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
-        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found",  detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex)   { return Problem(title: "Forbidden",  detail: ex.Message, statusCode: 403); }
     }
 
     [HttpPut("command-frequencies")]
@@ -66,7 +66,7 @@ public class FrequenciesController : ControllerBase
             var dto = await _frequencyService.UpdateCommandFrequencyAsync(eventId, request.Primary, request.Backup);
             return Ok(dto);
         }
-        catch (KeyNotFoundException ex) { return NotFound(new { error = ex.Message }); }
-        catch (ForbiddenException ex)   { return StatusCode(403, new { error = ex.Message }); }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found",  detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex)   { return Problem(title: "Forbidden",  detail: ex.Message, statusCode: 403); }
     }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/Faction.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/Faction.cs
@@ -10,4 +10,6 @@ public class Faction
     public AppUser Commander { get; set; } = null!;
     public ICollection<Platoon> Platoons { get; set; } = [];
     public ICollection<EventPlayer> Players { get; set; } = [];
+    public string? CommandPrimaryFrequency { get; set; }
+    public string? CommandBackupFrequency { get; set; }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/Platoon.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/Platoon.cs
@@ -10,4 +10,6 @@ public class Platoon
     public Faction Faction { get; set; } = null!;
     public ICollection<Squad> Squads { get; set; } = [];
     public ICollection<EventPlayer> Players { get; set; } = [];
+    public string? PlatoonPrimaryFrequency { get; set; }
+    public string? PlatoonBackupFrequency { get; set; }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/Squad.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/Squad.cs
@@ -8,4 +8,6 @@ public class Squad
     public int Order { get; set; }
     public Platoon Platoon { get; set; } = null!;
     public ICollection<EventPlayer> Players { get; set; } = [];
+    public string? SquadPrimaryFrequency { get; set; }
+    public string? SquadBackupFrequency { get; set; }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260331175016_AddFrequencyFieldsToHierarchyEntities.Designer.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260331175016_AddFrequencyFieldsToHierarchyEntities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MilsimPlanning.Api.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MilsimPlanning.Api.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260331175016_AddFrequencyFieldsToHierarchyEntities")]
+    partial class AddFrequencyFieldsToHierarchyEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260331175016_AddFrequencyFieldsToHierarchyEntities.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260331175016_AddFrequencyFieldsToHierarchyEntities.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MilsimPlanning.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFrequencyFieldsToHierarchyEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SquadBackupFrequency",
+                table: "Squads",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SquadPrimaryFrequency",
+                table: "Squads",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlatoonBackupFrequency",
+                table: "Platoons",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PlatoonPrimaryFrequency",
+                table: "Platoons",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CommandBackupFrequency",
+                table: "Factions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CommandPrimaryFrequency",
+                table: "Factions",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SquadBackupFrequency",
+                table: "Squads");
+
+            migrationBuilder.DropColumn(
+                name: "SquadPrimaryFrequency",
+                table: "Squads");
+
+            migrationBuilder.DropColumn(
+                name: "PlatoonBackupFrequency",
+                table: "Platoons");
+
+            migrationBuilder.DropColumn(
+                name: "PlatoonPrimaryFrequency",
+                table: "Platoons");
+
+            migrationBuilder.DropColumn(
+                name: "CommandBackupFrequency",
+                table: "Factions");
+
+            migrationBuilder.DropColumn(
+                name: "CommandPrimaryFrequency",
+                table: "Factions");
+        }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Frequencies/FrequencyDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Frequencies/FrequencyDto.cs
@@ -1,0 +1,8 @@
+namespace MilsimPlanning.Api.Models.Frequencies;
+
+public class FrequencyDto
+{
+    public FrequencyLevelDto? Squad   { get; set; }
+    public FrequencyLevelDto? Platoon { get; set; }
+    public FrequencyLevelDto? Command { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Frequencies/FrequencyLevelDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Frequencies/FrequencyLevelDto.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.Frequencies;
+
+public class FrequencyLevelDto
+{
+    public string? Primary { get; set; }
+    public string? Backup  { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Frequencies/UpdateFrequencyRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Frequencies/UpdateFrequencyRequest.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.Frequencies;
+
+public class UpdateFrequencyRequest
+{
+    public string? Primary { get; set; }
+    public string? Backup  { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Program.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Program.cs
@@ -122,6 +122,7 @@ builder.Services.AddScoped<MagicLinkService>();
 builder.Services.AddScoped<EventService>();
 builder.Services.AddScoped<RosterService>();
 builder.Services.AddScoped<HierarchyService>();
+builder.Services.AddScoped<FrequencyService>();
 builder.Services.AddScoped<IContentService, ContentService>();
 builder.Services.AddScoped<IMapResourceService, MapResourceService>();
 

--- a/milsim-platform/src/MilsimPlanning.Api/Services/FrequencyService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/FrequencyService.cs
@@ -1,0 +1,146 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Domain;
+using MilsimPlanning.Api.Models.Frequencies;
+
+namespace MilsimPlanning.Api.Services;
+
+public class FrequencyService
+{
+    private readonly AppDbContext _db;
+    private readonly ICurrentUser _currentUser;
+
+    public FrequencyService(AppDbContext db, ICurrentUser currentUser)
+    {
+        _db          = db;
+        _currentUser = currentUser;
+    }
+
+    // ── GET /api/events/{eventId}/frequencies ─────────────────────────────────
+
+    public async Task<FrequencyDto> GetFrequenciesAsync(Guid eventId)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var ep = await _db.EventPlayers
+            .Include(e => e.Squad)
+                .ThenInclude(s => s!.Platoon)
+                    .ThenInclude(p => p!.Faction)
+            .Include(e => e.Platoon)
+                .ThenInclude(p => p!.Faction)
+            .FirstOrDefaultAsync(e => e.EventId == eventId && e.UserId == _currentUser.UserId);
+
+        // Player/squad_leader/platoon_leader must have an EventPlayer record
+        if (ep is null
+            && _currentUser.Role != AppRoles.FactionCommander
+            && _currentUser.Role != AppRoles.SystemAdmin)
+        {
+            throw new KeyNotFoundException($"EventPlayer for event {eventId} not found");
+        }
+
+        var faction = await _db.Factions.FirstOrDefaultAsync(f => f.EventId == eventId);
+
+        return _currentUser.Role switch
+        {
+            AppRoles.Player => new FrequencyDto
+            {
+                Squad   = ToLevelDto(ep?.Squad),
+                Platoon = null,
+                Command = null
+            },
+            AppRoles.SquadLeader => new FrequencyDto
+            {
+                Squad   = ToLevelDto(ep?.Squad),
+                Platoon = ToLevelDto(ep?.Squad?.Platoon),
+                Command = null
+            },
+            AppRoles.PlatoonLeader => new FrequencyDto
+            {
+                Squad   = null,
+                Platoon = ToLevelDto(ep?.Platoon),
+                Command = ToLevelDto(faction)
+            },
+            _ => new FrequencyDto // faction_commander, system_admin
+            {
+                Squad   = null,
+                Platoon = null,
+                Command = ToLevelDto(faction)
+            }
+        };
+    }
+
+    // ── PUT /api/events/{eventId}/squads/{squadId}/frequencies ────────────────
+
+    public async Task<FrequencyLevelDto> UpdateSquadFrequencyAsync(
+        Guid eventId, Guid squadId, string? primary, string? backup)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var squad = await _db.Squads
+            .Include(s => s.Platoon)
+                .ThenInclude(p => p.Faction)
+            .FirstOrDefaultAsync(s => s.Id == squadId)
+            ?? throw new KeyNotFoundException($"Squad {squadId} not found");
+
+        if (squad.Platoon.Faction.EventId != eventId)
+            throw new ForbiddenException($"Squad {squadId} does not belong to event {eventId}");
+
+        squad.SquadPrimaryFrequency = primary;
+        squad.SquadBackupFrequency  = backup;
+        await _db.SaveChangesAsync();
+
+        return ToLevelDto(squad)!;
+    }
+
+    // ── PUT /api/events/{eventId}/platoons/{platoonId}/frequencies ────────────
+
+    public async Task<FrequencyLevelDto> UpdatePlatoonFrequencyAsync(
+        Guid eventId, Guid platoonId, string? primary, string? backup)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var platoon = await _db.Platoons
+            .Include(p => p.Faction)
+            .FirstOrDefaultAsync(p => p.Id == platoonId)
+            ?? throw new KeyNotFoundException($"Platoon {platoonId} not found");
+
+        if (platoon.Faction.EventId != eventId)
+            throw new ForbiddenException($"Platoon {platoonId} does not belong to event {eventId}");
+
+        platoon.PlatoonPrimaryFrequency = primary;
+        platoon.PlatoonBackupFrequency  = backup;
+        await _db.SaveChangesAsync();
+
+        return ToLevelDto(platoon)!;
+    }
+
+    // ── PUT /api/events/{eventId}/command-frequencies ─────────────────────────
+
+    public async Task<FrequencyLevelDto> UpdateCommandFrequencyAsync(
+        Guid eventId, string? primary, string? backup)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var faction = await _db.Factions.FirstOrDefaultAsync(f => f.EventId == eventId)
+            ?? throw new KeyNotFoundException($"Faction for event {eventId} not found");
+
+        faction.CommandPrimaryFrequency = primary;
+        faction.CommandBackupFrequency  = backup;
+        await _db.SaveChangesAsync();
+
+        return ToLevelDto(faction)!;
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private static FrequencyLevelDto? ToLevelDto(Squad? s) =>
+        new() { Primary = s?.SquadPrimaryFrequency, Backup = s?.SquadBackupFrequency };
+
+    private static FrequencyLevelDto? ToLevelDto(Platoon? p) =>
+        new() { Primary = p?.PlatoonPrimaryFrequency, Backup = p?.PlatoonBackupFrequency };
+
+    private static FrequencyLevelDto? ToLevelDto(Faction? f) =>
+        f is null ? null : new() { Primary = f.CommandPrimaryFrequency, Backup = f.CommandBackupFrequency };
+}


### PR DESCRIPTION
## Summary
- Add 6 nullable frequency columns to Squad, Platoon, Faction entities with EF Core migration
- Implement FrequencyService with role-based visibility (player sees squad only, squad_leader sees squad+platoon, platoon_leader sees platoon+command, commander sees command only)
- Implement FrequenciesController: GET /frequencies + PUT squad/platoon/command-frequencies
- 13 new integration tests (108 baseline → 121 total), all passing

## Test plan
- [x] `dotnet test` — 121 passing, 0 failing
- [x] Docker Compose up — all 3 containers healthy
- [x] GET /api/events/{eventId}/frequencies → 200 (role-filtered)
- [x] PUT /api/events/{eventId}/command-frequencies → 200
- [x] PUT /api/events/{eventId}/squads/{squadId}/frequencies → 200
- [x] Unauthenticated GET → 401
- [x] Player attempting PUT → 403
- [x] Cross-event squad IDOR → 403

Closes HEX-63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)