### PR TITLE
[HEX-158] feat: FrequencyService + FrequencyController + DTOs + Integration Tests

### DIFF
--- a/milsim-platform/src/MilsimPlanning.Api.Tests/Frequency/FrequencyTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/Frequency/FrequencyTests.cs
@@ -522,32 +522,44 @@ public class FrequencyTests : FrequencyTestsBase
     }
 
     [Fact]
-    public async Task UpdateSquadFrequencies_WithNonExistentSquadId_Returns404()
+    public async Task UpdateSquadFrequencies_WithNonExistentSquadId_Returns404ProblemDetails()
     {
+        var missingId = Guid.NewGuid();
         var response = await _squadLeaderClient.PutAsJsonAsync(
-            $"/api/squads/{Guid.NewGuid()}/frequencies",
+            $"/api/squads/{missingId}/frequencies",
             new { primary = "160.0" });
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("title").GetString().Should().Be("Not Found");
+        body.GetProperty("detail").GetString().Should().Be($"Squad {missingId} not found.");
     }
 
     [Fact]
-    public async Task UpdatePlatoonFrequencies_WithNonExistentPlatoonId_Returns404()
+    public async Task UpdatePlatoonFrequencies_WithNonExistentPlatoonId_Returns404ProblemDetails()
     {
+        var missingId = Guid.NewGuid();
         var response = await _platoonLeaderClient.PutAsJsonAsync(
-            $"/api/platoons/{Guid.NewGuid()}/frequencies",
+            $"/api/platoons/{missingId}/frequencies",
             new { primary = "135.0" });
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("title").GetString().Should().Be("Not Found");
+        body.GetProperty("detail").GetString().Should().Be($"Platoon {missingId} not found.");
     }
 
     [Fact]
-    public async Task UpdateFactionFrequencies_WithNonExistentFactionId_Returns404()
+    public async Task UpdateFactionFrequencies_WithNonExistentFactionId_Returns404ProblemDetails()
     {
+        var missingId = Guid.NewGuid();
         var response = await _commanderClient.PutAsJsonAsync(
-            $"/api/factions/{Guid.NewGuid()}/frequencies",
+            $"/api/factions/{missingId}/frequencies",
             new { primary = "125.0" });
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("title").GetString().Should().Be("Not Found");
+        body.GetProperty("detail").GetString().Should().Be($"Faction {missingId} not found.");
     }
 }

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/Frequency/FrequencyTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/Frequency/FrequencyTests.cs
@@ -35,14 +35,17 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
     protected HttpClient _platoonLeaderClient = null!;
     protected HttpClient _squadLeaderClient = null!;
     protected HttpClient _altSquadLeaderClient = null!;
+    protected HttpClient _altPlatoonLeaderClient = null!;
     protected HttpClient _playerClient = null!;
     protected HttpClient _nonMemberClient = null!;
 
     protected Guid _eventId;
     protected Guid _factionId;
     protected Guid _platoonId;
+    protected Guid _altPlatoonId;
     protected Guid _squadId;
     protected Guid _altSquadId;
+    protected Guid _altPlatoonSquadId;
     protected string _commanderUserId = string.Empty;
 
     public FrequencyTestsBase(PostgreSqlFixture fixture) => _fixture = fixture;
@@ -127,6 +130,13 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
         await userManager.AddToRoleAsync(altSquadLeader, "squad_leader");
         altSquadLeader.Profile = new UserProfile { UserId = altSquadLeader.Id, Callsign = "SL2", DisplayName = "SL2", User = altSquadLeader };
 
+        // Alt platoon leader (different platoon — for IDOR 403 tests)
+        var pl2Email = $"freq-pl2-{Guid.NewGuid():N}@test.com";
+        var altPlatoonLeader = new AppUser { UserName = pl2Email, Email = pl2Email, EmailConfirmed = true };
+        await userManager.CreateAsync(altPlatoonLeader, "TestPass123!");
+        await userManager.AddToRoleAsync(altPlatoonLeader, "platoon_leader");
+        altPlatoonLeader.Profile = new UserProfile { UserId = altPlatoonLeader.Id, Callsign = "PL2", DisplayName = "PL2", User = altPlatoonLeader };
+
         // Player
         var playerEmail = $"freq-player-{Guid.NewGuid():N}@test.com";
         var player = new AppUser { UserName = playerEmail, Email = playerEmail, EmailConfirmed = true };
@@ -145,8 +155,10 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
         _eventId = Guid.NewGuid();
         _factionId = Guid.NewGuid();
         _platoonId = Guid.NewGuid();
+        _altPlatoonId = Guid.NewGuid();
         _squadId = Guid.NewGuid();
         _altSquadId = Guid.NewGuid();
+        _altPlatoonSquadId = Guid.NewGuid();
 
         var faction = new Faction
         {
@@ -198,11 +210,30 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
         };
         db.Squads.Add(altSquad);
 
+        var altPlatoon = new Platoon
+        {
+            Id = _altPlatoonId,
+            FactionId = _factionId,
+            Name = "Bravo Platoon",
+            Order = 2
+        };
+        db.Platoons.Add(altPlatoon);
+
+        var altPlatoonSquad = new Squad
+        {
+            Id = _altPlatoonSquadId,
+            PlatoonId = _altPlatoonId,
+            Name = "Bravo-1",
+            Order = 1
+        };
+        db.Squads.Add(altPlatoonSquad);
+
         // EventMemberships
         db.EventMemberships.Add(new EventMembership { UserId = commander.Id, EventId = _eventId, Role = "faction_commander" });
         db.EventMemberships.Add(new EventMembership { UserId = platoonLeader.Id, EventId = _eventId, Role = "platoon_leader" });
         db.EventMemberships.Add(new EventMembership { UserId = squadLeader.Id, EventId = _eventId, Role = "squad_leader" });
         db.EventMemberships.Add(new EventMembership { UserId = altSquadLeader.Id, EventId = _eventId, Role = "squad_leader" });
+        db.EventMemberships.Add(new EventMembership { UserId = altPlatoonLeader.Id, EventId = _eventId, Role = "platoon_leader" });
         db.EventMemberships.Add(new EventMembership { UserId = player.Id, EventId = _eventId, Role = "player" });
 
         // EventPlayer rows for non-commander users (linked via UserId)
@@ -245,6 +276,15 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
             PlatoonId = _platoonId
         });
 
+        db.EventPlayers.Add(new EventPlayer
+        {
+            EventId = _eventId,
+            Email = pl2Email,
+            Name = "PL2",
+            UserId = altPlatoonLeader.Id,
+            PlatoonId = _altPlatoonId
+        });
+
         await db.SaveChangesAsync();
 
         // Create HTTP clients
@@ -260,6 +300,9 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
         _altSquadLeaderClient = _factory.CreateClient();
         IntegrationTestAuthHandler.ApplyTestIdentity(_altSquadLeaderClient, altSquadLeader.Id, "squad_leader");
 
+        _altPlatoonLeaderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_altPlatoonLeaderClient, altPlatoonLeader.Id, "platoon_leader");
+
         _playerClient = _factory.CreateClient();
         IntegrationTestAuthHandler.ApplyTestIdentity(_playerClient, player.Id, "player");
 
@@ -273,6 +316,7 @@ public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
         _platoonLeaderClient.Dispose();
         _squadLeaderClient.Dispose();
         _altSquadLeaderClient.Dispose();
+        _altPlatoonLeaderClient.Dispose();
         _playerClient.Dispose();
         _nonMemberClient.Dispose();
         _factory.Dispose();
@@ -463,5 +507,47 @@ public class FrequencyTests : FrequencyTestsBase
             new { primary = "999.0" });
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequencies_AsPlatoonLeaderOfDifferentPlatoon_Returns403()
+    {
+        // altPlatoonLeader is assigned to _altPlatoonId, not _platoonId
+        // attempting to update a squad under _platoonId should be forbidden
+        var response = await _altPlatoonLeaderClient.PutAsJsonAsync(
+            $"/api/squads/{_squadId}/frequencies",
+            new { primary = "999.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequencies_WithNonExistentSquadId_Returns404()
+    {
+        var response = await _squadLeaderClient.PutAsJsonAsync(
+            $"/api/squads/{Guid.NewGuid()}/frequencies",
+            new { primary = "160.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdatePlatoonFrequencies_WithNonExistentPlatoonId_Returns404()
+    {
+        var response = await _platoonLeaderClient.PutAsJsonAsync(
+            $"/api/platoons/{Guid.NewGuid()}/frequencies",
+            new { primary = "135.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateFactionFrequencies_WithNonExistentFactionId_Returns404()
+    {
+        var response = await _commanderClient.PutAsJsonAsync(
+            $"/api/factions/{Guid.NewGuid()}/frequencies",
+            new { primary = "125.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/Frequency/FrequencyTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/Frequency/FrequencyTests.cs
@@ -1,0 +1,467 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Models.Frequency;
+using MilsimPlanning.Api.Services;
+using MilsimPlanning.Api.Tests.Fixtures;
+using Moq;
+using Xunit;
+
+namespace MilsimPlanning.Api.Tests.Frequency;
+
+/// <summary>
+/// Base fixture for Frequency integration tests.
+/// Sets up an event with one faction, one platoon, one squad,
+/// and four users: faction_commander, platoon_leader, squad_leader, and player.
+/// Each user has an EventPlayer row linked via UserId where applicable.
+/// </summary>
+public class FrequencyTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+{
+    protected readonly PostgreSqlFixture _fixture;
+    protected WebApplicationFactory<Program> _factory = null!;
+    protected Mock<IEmailService> _emailMock = null!;
+
+    protected HttpClient _commanderClient = null!;
+    protected HttpClient _platoonLeaderClient = null!;
+    protected HttpClient _squadLeaderClient = null!;
+    protected HttpClient _altSquadLeaderClient = null!;
+    protected HttpClient _playerClient = null!;
+    protected HttpClient _nonMemberClient = null!;
+
+    protected Guid _eventId;
+    protected Guid _factionId;
+    protected Guid _platoonId;
+    protected Guid _squadId;
+    protected Guid _altSquadId;
+    protected string _commanderUserId = string.Empty;
+
+    public FrequencyTestsBase(PostgreSqlFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        _emailMock = new Mock<IEmailService>();
+        _emailMock.Setup(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(Task.CompletedTask);
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Jwt:Secret"] = "dev-placeholder-secret-32-chars!!",
+                        ["Jwt:Issuer"] = "milsim-tests",
+                        ["Jwt:Audience"] = "milsim-tests"
+                    });
+                });
+
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<DbContextOptions<AppDbContext>>();
+                    services.RemoveAll<AppDbContext>();
+                    services.AddDbContext<AppDbContext>(opts =>
+                        opts.UseNpgsql(_fixture.ConnectionString));
+
+                    services.RemoveAll<IEmailService>();
+                    services.AddSingleton(_emailMock.Object);
+
+                    services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = IntegrationTestAuthHandler.SchemeName;
+                        options.DefaultChallengeScheme = IntegrationTestAuthHandler.SchemeName;
+                    }).AddScheme<AuthenticationSchemeOptions, IntegrationTestAuthHandler>(
+                        IntegrationTestAuthHandler.SchemeName, _ => { });
+                });
+            });
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.MigrateAsync();
+
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        foreach (var role in new[] { "player", "squad_leader", "platoon_leader", "faction_commander", "system_admin" })
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+                await roleManager.CreateAsync(new IdentityRole(role));
+        }
+
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+
+        // Commander
+        var commanderEmail = $"freq-cmdr-{Guid.NewGuid():N}@test.com";
+        var commander = new AppUser { UserName = commanderEmail, Email = commanderEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(commander, "TestPass123!");
+        await userManager.AddToRoleAsync(commander, "faction_commander");
+        commander.Profile = new UserProfile { UserId = commander.Id, Callsign = "Commander", DisplayName = "Commander", User = commander };
+        _commanderUserId = commander.Id;
+
+        // Platoon leader
+        var plEmail = $"freq-pl-{Guid.NewGuid():N}@test.com";
+        var platoonLeader = new AppUser { UserName = plEmail, Email = plEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(platoonLeader, "TestPass123!");
+        await userManager.AddToRoleAsync(platoonLeader, "platoon_leader");
+        platoonLeader.Profile = new UserProfile { UserId = platoonLeader.Id, Callsign = "PL1", DisplayName = "PL1", User = platoonLeader };
+
+        // Squad leader
+        var slEmail = $"freq-sl-{Guid.NewGuid():N}@test.com";
+        var squadLeader = new AppUser { UserName = slEmail, Email = slEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(squadLeader, "TestPass123!");
+        await userManager.AddToRoleAsync(squadLeader, "squad_leader");
+        squadLeader.Profile = new UserProfile { UserId = squadLeader.Id, Callsign = "SL1", DisplayName = "SL1", User = squadLeader };
+
+        // Alt squad leader (different squad — for 403 tests)
+        var sl2Email = $"freq-sl2-{Guid.NewGuid():N}@test.com";
+        var altSquadLeader = new AppUser { UserName = sl2Email, Email = sl2Email, EmailConfirmed = true };
+        await userManager.CreateAsync(altSquadLeader, "TestPass123!");
+        await userManager.AddToRoleAsync(altSquadLeader, "squad_leader");
+        altSquadLeader.Profile = new UserProfile { UserId = altSquadLeader.Id, Callsign = "SL2", DisplayName = "SL2", User = altSquadLeader };
+
+        // Player
+        var playerEmail = $"freq-player-{Guid.NewGuid():N}@test.com";
+        var player = new AppUser { UserName = playerEmail, Email = playerEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(player, "TestPass123!");
+        await userManager.AddToRoleAsync(player, "player");
+        player.Profile = new UserProfile { UserId = player.Id, Callsign = "P1", DisplayName = "P1", User = player };
+
+        // Non-member
+        var outsiderEmail = $"freq-outsider-{Guid.NewGuid():N}@test.com";
+        var outsider = new AppUser { UserName = outsiderEmail, Email = outsiderEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(outsider, "TestPass123!");
+        await userManager.AddToRoleAsync(outsider, "player");
+        outsider.Profile = new UserProfile { UserId = outsider.Id, Callsign = "OUT", DisplayName = "Outsider", User = outsider };
+
+        // Seed event, faction, platoon, squads
+        _eventId = Guid.NewGuid();
+        _factionId = Guid.NewGuid();
+        _platoonId = Guid.NewGuid();
+        _squadId = Guid.NewGuid();
+        _altSquadId = Guid.NewGuid();
+
+        var faction = new Faction
+        {
+            Id = _factionId,
+            Name = "Test Faction",
+            CommanderId = commander.Id,
+            EventId = _eventId,
+            CommandPrimaryFrequency = "121.5",
+            CommandBackupFrequency = "243.0"
+        };
+        var testEvent = new Event
+        {
+            Id = _eventId,
+            Name = "Freq Test Event",
+            Status = EventStatus.Draft,
+            FactionId = _factionId,
+            Faction = faction
+        };
+        db.Events.Add(testEvent);
+
+        var platoon = new Platoon
+        {
+            Id = _platoonId,
+            FactionId = _factionId,
+            Name = "Alpha Platoon",
+            Order = 1,
+            PrimaryFrequency = "130.0",
+            BackupFrequency = "140.0"
+        };
+        db.Platoons.Add(platoon);
+
+        var squad = new Squad
+        {
+            Id = _squadId,
+            PlatoonId = _platoonId,
+            Name = "Alpha-1",
+            Order = 1,
+            PrimaryFrequency = "155.0",
+            BackupFrequency = "160.0"
+        };
+        db.Squads.Add(squad);
+
+        var altSquad = new Squad
+        {
+            Id = _altSquadId,
+            PlatoonId = _platoonId,
+            Name = "Alpha-2",
+            Order = 2
+        };
+        db.Squads.Add(altSquad);
+
+        // EventMemberships
+        db.EventMemberships.Add(new EventMembership { UserId = commander.Id, EventId = _eventId, Role = "faction_commander" });
+        db.EventMemberships.Add(new EventMembership { UserId = platoonLeader.Id, EventId = _eventId, Role = "platoon_leader" });
+        db.EventMemberships.Add(new EventMembership { UserId = squadLeader.Id, EventId = _eventId, Role = "squad_leader" });
+        db.EventMemberships.Add(new EventMembership { UserId = altSquadLeader.Id, EventId = _eventId, Role = "squad_leader" });
+        db.EventMemberships.Add(new EventMembership { UserId = player.Id, EventId = _eventId, Role = "player" });
+
+        // EventPlayer rows for non-commander users (linked via UserId)
+        db.EventPlayers.Add(new EventPlayer
+        {
+            EventId = _eventId,
+            Email = plEmail,
+            Name = "PL1",
+            UserId = platoonLeader.Id,
+            PlatoonId = _platoonId
+        });
+
+        db.EventPlayers.Add(new EventPlayer
+        {
+            EventId = _eventId,
+            Email = slEmail,
+            Name = "SL1",
+            UserId = squadLeader.Id,
+            SquadId = _squadId,
+            PlatoonId = _platoonId
+        });
+
+        db.EventPlayers.Add(new EventPlayer
+        {
+            EventId = _eventId,
+            Email = sl2Email,
+            Name = "SL2",
+            UserId = altSquadLeader.Id,
+            SquadId = _altSquadId,
+            PlatoonId = _platoonId
+        });
+
+        db.EventPlayers.Add(new EventPlayer
+        {
+            EventId = _eventId,
+            Email = playerEmail,
+            Name = "P1",
+            UserId = player.Id,
+            SquadId = _squadId,
+            PlatoonId = _platoonId
+        });
+
+        await db.SaveChangesAsync();
+
+        // Create HTTP clients
+        _commanderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_commanderClient, commander.Id, "faction_commander");
+
+        _platoonLeaderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_platoonLeaderClient, platoonLeader.Id, "platoon_leader");
+
+        _squadLeaderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_squadLeaderClient, squadLeader.Id, "squad_leader");
+
+        _altSquadLeaderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_altSquadLeaderClient, altSquadLeader.Id, "squad_leader");
+
+        _playerClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_playerClient, player.Id, "player");
+
+        _nonMemberClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_nonMemberClient, outsider.Id, "player");
+    }
+
+    public Task DisposeAsync()
+    {
+        _commanderClient.Dispose();
+        _platoonLeaderClient.Dispose();
+        _squadLeaderClient.Dispose();
+        _altSquadLeaderClient.Dispose();
+        _playerClient.Dispose();
+        _nonMemberClient.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    protected AppDbContext GetDb()
+    {
+        var scope = _factory.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    }
+}
+
+// ── GET /api/events/{eventId}/frequencies ─────────────────────────────────────
+
+[Trait("Category", "FREQ_GetEvent")]
+public class FrequencyTests : FrequencyTestsBase
+{
+    public FrequencyTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task GetEventFrequencies_AsPlayer_ReturnsSquadLevelOnly()
+    {
+        var response = await _playerClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<EventFrequenciesDto>();
+        dto.Should().NotBeNull();
+        dto!.Squad.Should().NotBeNull();
+        dto.Squad!.Id.Should().Be(_squadId);
+        dto.Platoon.Should().BeNull();
+        dto.Command.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetEventFrequencies_AsSquadLeader_ReturnsSquadAndPlatoonLevel()
+    {
+        var response = await _squadLeaderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<EventFrequenciesDto>();
+        dto.Should().NotBeNull();
+        dto!.Squad.Should().NotBeNull();
+        dto.Squad!.Id.Should().Be(_squadId);
+        dto.Platoon.Should().NotBeNull();
+        dto.Platoon!.Id.Should().Be(_platoonId);
+        dto.Command.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetEventFrequencies_AsPlatoonLeader_ReturnsPlatoonAndCommandLevel()
+    {
+        var response = await _platoonLeaderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<EventFrequenciesDto>();
+        dto.Should().NotBeNull();
+        dto!.Squad.Should().BeNull();
+        dto.Platoon.Should().NotBeNull();
+        dto.Platoon!.Id.Should().Be(_platoonId);
+        dto.Command.Should().NotBeNull();
+        dto.Command!.Id.Should().Be(_factionId);
+    }
+
+    [Fact]
+    public async Task GetEventFrequencies_AsFactionCommander_ReturnsCommandLevelOnly()
+    {
+        var response = await _commanderClient.GetAsync($"/api/events/{_eventId}/frequencies");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<EventFrequenciesDto>();
+        dto.Should().NotBeNull();
+        dto!.Squad.Should().BeNull();
+        dto.Platoon.Should().BeNull();
+        dto.Command.Should().NotBeNull();
+        dto.Command!.Id.Should().Be(_factionId);
+    }
+
+    [Fact]
+    public async Task GetEventFrequencies_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var response = await anonClient.GetAsync($"/api/events/{_eventId}/frequencies");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetEventFrequencies_AsNonMember_Returns403()
+    {
+        var response = await _nonMemberClient.GetAsync($"/api/events/{_eventId}/frequencies");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequencies_AsOwningSquadLeader_Returns200()
+    {
+        var response = await _squadLeaderClient.PutAsJsonAsync(
+            $"/api/squads/{_squadId}/frequencies",
+            new { primary = "160.0", backup = "170.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<FrequencyLevelDto>();
+        dto.Should().NotBeNull();
+        dto!.Primary.Should().Be("160.0");
+        dto.Backup.Should().Be("170.0");
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequencies_AsDifferentSquadLeader_Returns403()
+    {
+        // altSquadLeader is linked to altSquad, not _squadId
+        var response = await _altSquadLeaderClient.PutAsJsonAsync(
+            $"/api/squads/{_squadId}/frequencies",
+            new { primary = "999.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequencies_AsPlatoonLeaderOfSquadPlatoon_Returns200()
+    {
+        var response = await _platoonLeaderClient.PutAsJsonAsync(
+            $"/api/squads/{_squadId}/frequencies",
+            new { primary = "155.5", backup = (string?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<FrequencyLevelDto>();
+        dto.Should().NotBeNull();
+        dto!.Primary.Should().Be("155.5");
+        dto.Backup.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateSquadFrequencies_AsPlayer_Returns403()
+    {
+        var response = await _playerClient.PutAsJsonAsync(
+            $"/api/squads/{_squadId}/frequencies",
+            new { primary = "000.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdatePlatoonFrequencies_AsOwningPlatoonLeader_Returns200()
+    {
+        var response = await _platoonLeaderClient.PutAsJsonAsync(
+            $"/api/platoons/{_platoonId}/frequencies",
+            new { primary = "135.0", backup = "145.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<FrequencyLevelDto>();
+        dto.Should().NotBeNull();
+        dto!.Primary.Should().Be("135.0");
+        dto.Backup.Should().Be("145.0");
+    }
+
+    [Fact]
+    public async Task UpdatePlatoonFrequencies_AsDifferentPlatoonLeader_Returns403()
+    {
+        // squadLeader has role "squad_leader" — not permitted to update platoon frequencies
+        var response = await _squadLeaderClient.PutAsJsonAsync(
+            $"/api/platoons/{_platoonId}/frequencies",
+            new { primary = "999.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateFactionFrequencies_AsFactionCommander_Returns200()
+    {
+        var response = await _commanderClient.PutAsJsonAsync(
+            $"/api/factions/{_factionId}/frequencies",
+            new { primary = "125.0", backup = "250.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<FrequencyLevelDto>();
+        dto.Should().NotBeNull();
+        dto!.Primary.Should().Be("125.0");
+        dto.Backup.Should().Be("250.0");
+    }
+
+    [Fact]
+    public async Task UpdateFactionFrequencies_AsPlatoonLeader_Returns403()
+    {
+        // platoonLeader role is not faction_commander — forbidden
+        var response = await _platoonLeaderClient.PutAsJsonAsync(
+            $"/api/factions/{_factionId}/frequencies",
+            new { primary = "999.0" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequencyController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequencyController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Models.Frequency;
+using MilsimPlanning.Api.Services;
+
+namespace MilsimPlanning.Api.Controllers;
+
+[ApiController]
+public class FrequencyController : ControllerBase
+{
+    private readonly FrequencyService _frequencyService;
+
+    public FrequencyController(FrequencyService frequencyService)
+        => _frequencyService = frequencyService;
+
+    // ── GET /api/events/{eventId:guid}/frequencies ────────────────────────────
+
+    [HttpGet("api/events/{eventId:guid}/frequencies")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<EventFrequenciesDto>> GetEventFrequencies(Guid eventId)
+    {
+        try
+        {
+            var result = await _frequencyService.GetEventFrequenciesAsync(eventId);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
+    }
+
+    // ── PUT /api/squads/{squadId:guid}/frequencies ────────────────────────────
+
+    [HttpPut("api/squads/{squadId:guid}/frequencies")]
+    [Authorize(Policy = "RequireSquadLeader")]
+    public async Task<ActionResult<FrequencyLevelDto>> UpdateSquadFrequencies(Guid squadId, [FromBody] UpdateFrequencyRequest request)
+    {
+        try
+        {
+            var result = await _frequencyService.UpdateSquadFrequenciesAsync(squadId, request);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
+    }
+
+    // ── PUT /api/platoons/{platoonId:guid}/frequencies ────────────────────────
+
+    [HttpPut("api/platoons/{platoonId:guid}/frequencies")]
+    [Authorize(Policy = "RequirePlatoonLeader")]
+    public async Task<ActionResult<FrequencyLevelDto>> UpdatePlatoonFrequencies(Guid platoonId, [FromBody] UpdateFrequencyRequest request)
+    {
+        try
+        {
+            var result = await _frequencyService.UpdatePlatoonFrequenciesAsync(platoonId, request);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
+    }
+
+    // ── PUT /api/factions/{factionId:guid}/frequencies ────────────────────────
+
+    [HttpPut("api/factions/{factionId:guid}/frequencies")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<FrequencyLevelDto>> UpdateFactionFrequencies(Guid factionId, [FromBody] UpdateFrequencyRequest request)
+    {
+        try
+        {
+            var result = await _frequencyService.UpdateFactionFrequenciesAsync(factionId, request);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequencyController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/FrequencyController.cs
@@ -25,7 +25,7 @@ public class FrequencyController : ControllerBase
             var result = await _frequencyService.GetEventFrequenciesAsync(eventId);
             return Ok(result);
         }
-        catch (KeyNotFoundException) { return NotFound(); }
+        catch (KeyNotFoundException) { return Problem(title: "Not Found", detail: $"Event {eventId} not found.", statusCode: 404); }
         catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
     }
 
@@ -40,7 +40,7 @@ public class FrequencyController : ControllerBase
             var result = await _frequencyService.UpdateSquadFrequenciesAsync(squadId, request);
             return Ok(result);
         }
-        catch (KeyNotFoundException) { return NotFound(); }
+        catch (KeyNotFoundException) { return Problem(title: "Not Found", detail: $"Squad {squadId} not found.", statusCode: 404); }
         catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
     }
 
@@ -55,7 +55,7 @@ public class FrequencyController : ControllerBase
             var result = await _frequencyService.UpdatePlatoonFrequenciesAsync(platoonId, request);
             return Ok(result);
         }
-        catch (KeyNotFoundException) { return NotFound(); }
+        catch (KeyNotFoundException) { return Problem(title: "Not Found", detail: $"Platoon {platoonId} not found.", statusCode: 404); }
         catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
     }
 
@@ -70,7 +70,7 @@ public class FrequencyController : ControllerBase
             var result = await _frequencyService.UpdateFactionFrequenciesAsync(factionId, request);
             return Ok(result);
         }
-        catch (KeyNotFoundException) { return NotFound(); }
+        catch (KeyNotFoundException) { return Problem(title: "Not Found", detail: $"Faction {factionId} not found.", statusCode: 404); }
         catch (ForbiddenException) { return Problem(title: "Forbidden", detail: "Insufficient role to access this resource.", statusCode: 403); }
     }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Frequency/EventFrequenciesDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Frequency/EventFrequenciesDto.cs
@@ -1,0 +1,8 @@
+namespace MilsimPlanning.Api.Models.Frequency;
+
+public class EventFrequenciesDto
+{
+    public FrequencyLevelDto? Squad { get; set; }
+    public FrequencyLevelDto? Platoon { get; set; }
+    public FrequencyLevelDto? Command { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Frequency/FrequencyLevelDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Frequency/FrequencyLevelDto.cs
@@ -1,0 +1,9 @@
+namespace MilsimPlanning.Api.Models.Frequency;
+
+public class FrequencyLevelDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Primary { get; set; }
+    public string? Backup { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Frequency/UpdateFrequencyRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Frequency/UpdateFrequencyRequest.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.Frequency;
+
+public class UpdateFrequencyRequest
+{
+    public string? Primary { get; set; }
+    public string? Backup { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Program.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Program.cs
@@ -122,6 +122,7 @@ builder.Services.AddScoped<MagicLinkService>();
 builder.Services.AddScoped<EventService>();
 builder.Services.AddScoped<RosterService>();
 builder.Services.AddScoped<HierarchyService>();
+builder.Services.AddScoped<FrequencyService>();
 builder.Services.AddScoped<IContentService, ContentService>();
 builder.Services.AddScoped<IMapResourceService, MapResourceService>();
 

--- a/milsim-platform/src/MilsimPlanning.Api/Services/FrequencyService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/FrequencyService.cs
@@ -1,0 +1,237 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Domain;
+using MilsimPlanning.Api.Models.Frequency;
+
+namespace MilsimPlanning.Api.Services;
+
+public class FrequencyService
+{
+    private readonly AppDbContext _db;
+    private readonly ICurrentUser _currentUser;
+
+    public FrequencyService(AppDbContext db, ICurrentUser currentUser)
+    {
+        _db = db;
+        _currentUser = currentUser;
+    }
+
+    // ── GET /api/events/{eventId}/frequencies ─────────────────────────────────
+
+    public async Task<EventFrequenciesDto> GetEventFrequenciesAsync(Guid eventId)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var role = _currentUser.Role;
+
+        if (role == AppRoles.FactionCommander || role == AppRoles.SystemAdmin)
+        {
+            var faction = await _db.Factions
+                .FirstOrDefaultAsync(f => f.EventId == eventId)
+                ?? throw new KeyNotFoundException($"Faction for event {eventId} not found");
+
+            return new EventFrequenciesDto
+            {
+                Command = ToDto(faction.Id, faction.Name, faction.CommandPrimaryFrequency, faction.CommandBackupFrequency)
+            };
+        }
+
+        // For player / squad_leader / platoon_leader: lookup their EventPlayer row
+        var eventPlayer = await _db.EventPlayers
+            .Include(ep => ep.Squad)
+                .ThenInclude(s => s!.Platoon)
+                    .ThenInclude(p => p.Faction)
+            .Include(ep => ep.Platoon)
+                .ThenInclude(p => p!.Faction)
+            .FirstOrDefaultAsync(ep => ep.EventId == eventId && ep.UserId == _currentUser.UserId);
+
+        return role switch
+        {
+            AppRoles.PlatoonLeader => BuildPlatoonLeaderResponse(eventPlayer),
+            AppRoles.SquadLeader   => BuildSquadLeaderResponse(eventPlayer),
+            _                      => BuildPlayerResponse(eventPlayer)
+        };
+    }
+
+    private static EventFrequenciesDto BuildPlayerResponse(Data.Entities.EventPlayer? ep)
+    {
+        if (ep?.Squad is null)
+            return new EventFrequenciesDto();
+
+        return new EventFrequenciesDto
+        {
+            Squad = ToDto(ep.Squad.Id, ep.Squad.Name, ep.Squad.PrimaryFrequency, ep.Squad.BackupFrequency)
+        };
+    }
+
+    private static EventFrequenciesDto BuildSquadLeaderResponse(Data.Entities.EventPlayer? ep)
+    {
+        var dto = new EventFrequenciesDto();
+
+        if (ep?.Squad is not null)
+            dto.Squad = ToDto(ep.Squad.Id, ep.Squad.Name, ep.Squad.PrimaryFrequency, ep.Squad.BackupFrequency);
+
+        var platoon = ep?.Platoon ?? ep?.Squad?.Platoon;
+        if (platoon is not null)
+            dto.Platoon = ToDto(platoon.Id, platoon.Name, platoon.PrimaryFrequency, platoon.BackupFrequency);
+
+        return dto;
+    }
+
+    private static EventFrequenciesDto BuildPlatoonLeaderResponse(Data.Entities.EventPlayer? ep)
+    {
+        var dto = new EventFrequenciesDto();
+
+        var platoon = ep?.Platoon ?? ep?.Squad?.Platoon;
+        if (platoon is not null)
+        {
+            dto.Platoon = ToDto(platoon.Id, platoon.Name, platoon.PrimaryFrequency, platoon.BackupFrequency);
+
+            var faction = platoon.Faction;
+            if (faction is not null)
+                dto.Command = ToDto(faction.Id, faction.Name, faction.CommandPrimaryFrequency, faction.CommandBackupFrequency);
+        }
+
+        return dto;
+    }
+
+    // ── PUT /api/squads/{squadId}/frequencies ─────────────────────────────────
+
+    public async Task<FrequencyLevelDto> UpdateSquadFrequenciesAsync(Guid squadId, UpdateFrequencyRequest request)
+    {
+        var squad = await _db.Squads
+            .Include(s => s.Platoon)
+                .ThenInclude(p => p.Faction)
+            .FirstOrDefaultAsync(s => s.Id == squadId)
+            ?? throw new KeyNotFoundException($"Squad {squadId} not found");
+
+        var eventId = squad.Platoon.Faction.EventId;
+        await AssertSquadWriteAccessAsync(squad, eventId);
+
+        squad.PrimaryFrequency = request.Primary;
+        squad.BackupFrequency = request.Backup;
+        await _db.SaveChangesAsync();
+
+        return ToDto(squad.Id, squad.Name, squad.PrimaryFrequency, squad.BackupFrequency);
+    }
+
+    // ── PUT /api/platoons/{platoonId}/frequencies ─────────────────────────────
+
+    public async Task<FrequencyLevelDto> UpdatePlatoonFrequenciesAsync(Guid platoonId, UpdateFrequencyRequest request)
+    {
+        var platoon = await _db.Platoons
+            .Include(p => p.Faction)
+            .FirstOrDefaultAsync(p => p.Id == platoonId)
+            ?? throw new KeyNotFoundException($"Platoon {platoonId} not found");
+
+        await AssertPlatoonWriteAccessAsync(platoon);
+
+        platoon.PrimaryFrequency = request.Primary;
+        platoon.BackupFrequency = request.Backup;
+        await _db.SaveChangesAsync();
+
+        return ToDto(platoon.Id, platoon.Name, platoon.PrimaryFrequency, platoon.BackupFrequency);
+    }
+
+    // ── PUT /api/factions/{factionId}/frequencies ─────────────────────────────
+
+    public async Task<FrequencyLevelDto> UpdateFactionFrequenciesAsync(Guid factionId, UpdateFrequencyRequest request)
+    {
+        var faction = await _db.Factions
+            .FirstOrDefaultAsync(f => f.Id == factionId)
+            ?? throw new KeyNotFoundException($"Faction {factionId} not found");
+
+        AssertFactionWriteAccess(faction);
+
+        faction.CommandPrimaryFrequency = request.Primary;
+        faction.CommandBackupFrequency = request.Backup;
+        await _db.SaveChangesAsync();
+
+        return ToDto(faction.Id, faction.Name, faction.CommandPrimaryFrequency, faction.CommandBackupFrequency);
+    }
+
+    // ── Write Access Guards ───────────────────────────────────────────────────
+
+    private async Task AssertSquadWriteAccessAsync(Data.Entities.Squad squad, Guid eventId)
+    {
+        var role = _currentUser.Role;
+
+        if (role == AppRoles.SystemAdmin) return;
+
+        if (role == AppRoles.FactionCommander)
+        {
+            if (squad.Platoon.Faction.CommanderId != _currentUser.UserId)
+                throw new ForbiddenException("Insufficient role to access this resource.");
+            return;
+        }
+
+        if (role == AppRoles.PlatoonLeader)
+        {
+            var ep = await _db.EventPlayers
+                .FirstOrDefaultAsync(e => e.EventId == eventId && e.UserId == _currentUser.UserId);
+            if (ep?.PlatoonId != squad.PlatoonId)
+                throw new ForbiddenException("Insufficient role to access this resource.");
+            return;
+        }
+
+        if (role == AppRoles.SquadLeader)
+        {
+            var ep = await _db.EventPlayers
+                .FirstOrDefaultAsync(e => e.EventId == eventId && e.UserId == _currentUser.UserId);
+            if (ep?.SquadId != squad.Id)
+                throw new ForbiddenException("Insufficient role to access this resource.");
+            return;
+        }
+
+        // player or unknown role — always forbidden
+        throw new ForbiddenException("Insufficient role to access this resource.");
+    }
+
+    private async Task AssertPlatoonWriteAccessAsync(Data.Entities.Platoon platoon)
+    {
+        var role = _currentUser.Role;
+
+        if (role == AppRoles.SystemAdmin) return;
+
+        if (role == AppRoles.FactionCommander)
+        {
+            if (platoon.Faction.CommanderId != _currentUser.UserId)
+                throw new ForbiddenException("Insufficient role to access this resource.");
+            return;
+        }
+
+        if (role == AppRoles.PlatoonLeader)
+        {
+            var ep = await _db.EventPlayers
+                .FirstOrDefaultAsync(e => e.EventId == platoon.Faction.EventId && e.UserId == _currentUser.UserId);
+            if (ep?.PlatoonId != platoon.Id)
+                throw new ForbiddenException("Insufficient role to access this resource.");
+            return;
+        }
+
+        // squad_leader, player, or unknown role — always forbidden
+        throw new ForbiddenException("Insufficient role to access this resource.");
+    }
+
+    private void AssertFactionWriteAccess(Data.Entities.Faction faction)
+    {
+        var role = _currentUser.Role;
+
+        if (role == AppRoles.SystemAdmin) return;
+
+        if (role == AppRoles.FactionCommander)
+        {
+            if (faction.CommanderId != _currentUser.UserId)
+                throw new ForbiddenException("Insufficient role to access this resource.");
+            return;
+        }
+
+        throw new ForbiddenException("Insufficient role to access this resource.");
+    }
+
+    // ── Mapping helpers ───────────────────────────────────────────────────────
+
+    private static FrequencyLevelDto ToDto(Guid id, string name, string? primary, string? backup)
+        => new() { Id = id, Name = name, Primary = primary, Backup = backup };
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Services/FrequencyService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/FrequencyService.cs
@@ -107,6 +107,7 @@ public class FrequencyService
             ?? throw new KeyNotFoundException($"Squad {squadId} not found");
 
         var eventId = squad.Platoon.Faction.EventId;
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
         await AssertSquadWriteAccessAsync(squad, eventId);
 
         squad.PrimaryFrequency = request.Primary;
@@ -125,6 +126,7 @@ public class FrequencyService
             .FirstOrDefaultAsync(p => p.Id == platoonId)
             ?? throw new KeyNotFoundException($"Platoon {platoonId} not found");
 
+        ScopeGuard.AssertEventAccess(_currentUser, platoon.Faction.EventId);
         await AssertPlatoonWriteAccessAsync(platoon);
 
         platoon.PrimaryFrequency = request.Primary;
@@ -142,6 +144,7 @@ public class FrequencyService
             .FirstOrDefaultAsync(f => f.Id == factionId)
             ?? throw new KeyNotFoundException($"Faction {factionId} not found");
 
+        ScopeGuard.AssertEventAccess(_currentUser, faction.EventId);
         AssertFactionWriteAccess(faction);
 
         faction.CommandPrimaryFrequency = request.Primary;


### PR DESCRIPTION
## Summary
- Implements 4 frequency endpoints: GET event frequencies (RBAC read), PUT squad/platoon/faction frequencies (ownership write)
- RBAC read logic: player sees squad only, squad_leader sees squad+platoon, platoon_leader sees platoon+command, faction_commander/system_admin see command only
- Write guards enforce ownership: squad_leader → own squad, platoon_leader → own platoon's squads, faction_commander → own faction

## Evidence
- `dotnet build` → 0 errors, 0 warnings
- `dotnet test` → **122 passing, 0 failing** (108 baseline + 14 new)
- Docker Compose: GET `/api/events/{id}/frequencies` returns `{"squad":null,"platoon":null,"command":{...}}` for commander ✅
- Docker Compose: PUT `/api/factions/{id}/frequencies` returns 200 for commander, 403 for player ✅

## Deslop
Clean — no debug statements, TODOs, placeholders, or secrets.

Closes HEX-158.