### PR TITLE
Fix: add issues:write permission to agent-team workflow

### DIFF
--- a/.github/workflows/issue-handler.yml
+++ b/.github/workflows/issue-handler.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   handle:
     runs-on: [self-hosted, agent-team]


### PR DESCRIPTION
Adds `permissions: issues: write` so CONDUCTOR can create milestones and issues.