### PR TITLE
[#438] Implement EventOwner Role and Authorization

### DIFF
--- a/milsim-platform/src/MilsimPlanning.Api.Tests/Authorization/AuthorizationTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/Authorization/AuthorizationTests.cs
@@ -85,7 +85,7 @@ public class AuthorizationTests : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
 
         // Ensure roles exist
         var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
-        foreach (var role in new[] { "player", "squad_leader", "platoon_leader", "faction_commander", "system_admin" })
+        foreach (var role in new[] { "player", "squad_leader", "platoon_leader", "faction_commander", "event_owner", "system_admin" })
         {
             if (!await roleManager.RoleExistsAsync(role))
                 await roleManager.CreateAsync(new IdentityRole(role));
@@ -197,9 +197,9 @@ public class AuthorizationTests : IClassFixture<PostgreSqlFixture>, IAsyncLifeti
         // Act: GET /api/roster/{eventId} — requires RequirePlayer; system_admin should pass
         var response = await client.GetAsync($"/api/events/{eventId}/roster");
 
-        // Assert: system_admin satisfies even the most restrictive roles (hierarchy 5 >= all)
+        // Assert: system_admin satisfies even the most restrictive roles (hierarchy 6 >= all)
         response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
-            because: "system_admin (level 5) satisfies all policies including RequireFactionCommander");
+            because: "system_admin (level 6) satisfies all policies including RequireFactionCommander");
         response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized,
             because: "JWT is valid and user is authenticated");
     }

--- a/milsim-platform/src/MilsimPlanning.Api/Domain/AppRoles.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Domain/AppRoles.cs
@@ -6,6 +6,7 @@ public static class AppRoles
     public const string SquadLeader      = "squad_leader";
     public const string PlatoonLeader    = "platoon_leader";
     public const string FactionCommander = "faction_commander";
+    public const string EventOwner       = "event_owner";
     public const string SystemAdmin      = "system_admin";
 
     public static readonly Dictionary<string, int> Hierarchy = new()
@@ -14,6 +15,7 @@ public static class AppRoles
         [SquadLeader] = 2,
         [PlatoonLeader] = 3,
         [FactionCommander] = 4,
-        [SystemAdmin] = 5
+        [EventOwner] = 5,
+        [SystemAdmin] = 6
     };
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Program.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Program.cs
@@ -57,13 +57,14 @@ builder.Services.AddAuthentication(options =>
 
 // ── Authorization ─────────────────────────────────────────────────────────────
 // MinimumRoleHandler is the single source of truth for all role hierarchy checks.
-// All 5 policies use the same handler — numeric comparison via AppRoles.Hierarchy.
+// All 6 policies use the same handler — numeric comparison via AppRoles.Hierarchy.
 builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("RequirePlayer",           p => p.AddRequirements(new MinimumRoleRequirement(AppRoles.Player)));
     options.AddPolicy("RequireSquadLeader",      p => p.AddRequirements(new MinimumRoleRequirement(AppRoles.SquadLeader)));
     options.AddPolicy("RequirePlatoonLeader",    p => p.AddRequirements(new MinimumRoleRequirement(AppRoles.PlatoonLeader)));
     options.AddPolicy("RequireFactionCommander", p => p.AddRequirements(new MinimumRoleRequirement(AppRoles.FactionCommander)));
+    options.AddPolicy("RequireEventOwner",       p => p.AddRequirements(new MinimumRoleRequirement(AppRoles.EventOwner)));
     options.AddPolicy("RequireSystemAdmin",      p => p.AddRequirements(new MinimumRoleRequirement(AppRoles.SystemAdmin)));
 });
 builder.Services.AddSingleton<IAuthorizationHandler, MinimumRoleHandler>();


### PR DESCRIPTION
## Summary

Implements the EventOwner role (level 5) in the authorization hierarchy, sitting between FactionCommander (level 4) and SystemAdmin (level 6), as specified in HLTD #390.

## Changes

### Backend Authorization Model
- **AppRoles.cs**: Added `EventOwner = "event_owner"` constant with numeric level 5
- **AppRoles.Hierarchy**: Inserted EventOwner at level 5, pushed SystemAdmin to level 6
- **Program.cs**: Added `RequireEventOwner` authorization policy
- **AuthorizationTests.cs**: Updated test fixtures and assertions

### What the Implementation Provides

✅ **AC-01**: EventOwner role exists with numeric level 5 in constants and database
✅ **AC-02**: EventOwner inherits all FactionCommander permissions via MinimumRoleHandler numeric comparison (5 >= 4)
✅ **AC-03**: EventOwner can invoke all FactionCommander-level operations via authorization policies
✅ **AC-04**: SystemAdmin role (level 6) overrides EventOwner in all authorization checks
✅ **AC-05**: EventOwner role is assignable through EventMembership table (existing schema, no breaking changes)

### Design Pattern Reuse

- **MinimumRoleHandler**: Uses numeric role level comparison (userLevel >= minLevel) — no code changes required
- **ScopeGuard**: Enforces event-scoped access via EventMembership table — no changes required
- **JWT Authorization**: Leverages existing ClaimTypes.Role claim parsing and policy framework

No breaking API changes. No database migrations required (EventMembership table already supports numeric roles).

## Test Results

```
Test Run Successful.
Total tests: 124
  Passed: 124
  Failed: 0
```

## Verification

- ✅ Backend builds: `dotnet build` — 0 warnings, 0 errors
- ✅ Frontend builds: `npm run build` — successful
- ✅ All authorization tests pass
- ✅ Role hierarchy numeric comparison validated
- ✅ IDOR scope guard tests still passing

🤖 Generated with Claude Code