### PR TITLE
[#905] feat: assign alternate frequency to unit within channel (Story 3)

### DIFF
--- a/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
@@ -505,3 +505,158 @@ public class ChannelAssignmentAlternateFrequencyTests : ChannelAssignmentTestsBa
         updated.GetProperty("alternateFrequency").ValueKind.Should().Be(JsonValueKind.Null);
     }
 }
+
+// ── AC-04: Frequency conflict detection tests ──────────────────────────────────
+
+[Trait("Category", "ChannelAssignment_ConflictDetection")]
+public class ChannelAssignmentConflictDetectionTests : ChannelAssignmentTestsBase
+{
+    public ChannelAssignmentConflictDetectionTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task CreateAssignment_DuplicatePrimaryFrequency_Returns409()
+    {
+        // First assignment succeeds
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 60.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad tries the same primary frequency on the same channel
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-2", Order = 2 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 60.500m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("60.500");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_PrimaryConflictsWithExistingAlternate_Returns409()
+    {
+        // First assignment with primary + alternate
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 62.500m, alternateFrequency = 62.525m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad tries primary that matches first squad's alternate
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-3", Order = 3 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 62.525m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("62.525");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_AlternateConflictsWithExistingPrimary_Returns409()
+    {
+        // First assignment
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 64.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad tries alternate that matches first squad's primary
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-4", Order = 4 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 64.525m, alternateFrequency = 64.500m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("64.500");
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_ConflictsWithOtherUnit_Returns409()
+    {
+        // Create two assignments with different frequencies
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 66.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-5", Order = 5 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 66.525m });
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        var secondId = secondBody.GetProperty("id").GetGuid();
+
+        // Try to update second to match first's frequency
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{secondId}",
+            new { primaryFrequency = 66.500m });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("66.500");
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_SameFrequency_NoConflictWithSelf_Returns200()
+    {
+        // Create assignment
+        var create = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 68.500m });
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await create.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update with same frequency — should not conflict with itself
+        var update = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 68.500m });
+
+        update.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_SameFrequencyDifferentChannel_Returns201()
+    {
+        // Assign on VHF channel
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 70.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Same squad, different channel — no conflict
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelUhfId, squadId = _squadId, primaryFrequency = 225.025m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
@@ -399,3 +399,109 @@ public class ChannelAssignmentCrudTests : ChannelAssignmentTestsBase
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }
+
+// ── Alternate frequency tests (Story 3) ───────────────────────────────────────
+
+[Trait("Category", "ChannelAssignment_AlternateFrequency")]
+public class ChannelAssignmentAlternateFrequencyTests : ChannelAssignmentTestsBase
+{
+    public ChannelAssignmentAlternateFrequencyTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task CreateAssignment_WithAlternateFrequency_Returns201WithBothFrequencies()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 36.525m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("primaryFrequency").GetDecimal().Should().Be(36.500m);
+        body.GetProperty("alternateFrequency").GetDecimal().Should().Be(36.525m);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_AlternateEqualsPrimary_Returns422WithMessage()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 36.500m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("Alternate frequency cannot match primary frequency");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_InvalidAlternateFrequency_Returns422()
+    {
+        // 90.0 MHz is out of VHF range
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 90.0m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("out of range");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_InvalidAlternateSpacing_Returns422()
+    {
+        // 36.012 does not align to 25 kHz spacing
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 36.012m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("25 kHz");
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_AddAlternateFrequency_Returns200()
+    {
+        // Create without alternate
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 50.500m });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update to add alternate
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 50.500m, alternateFrequency = 50.525m });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        updated.GetProperty("primaryFrequency").GetDecimal().Should().Be(50.500m);
+        updated.GetProperty("alternateFrequency").GetDecimal().Should().Be(50.525m);
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_RemoveAlternateFrequency_Returns200WithNullAlternate()
+    {
+        // Create with alternate
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 55.500m, alternateFrequency = 55.525m });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update with null alternate (removes it)
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 55.500m, alternateFrequency = (decimal?)null });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        updated.GetProperty("primaryFrequency").GetDecimal().Should().Be(55.500m);
+        // alternateFrequency should be null
+        updated.GetProperty("alternateFrequency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Authorization/Exceptions/FrequencyConflictException.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Authorization/Exceptions/FrequencyConflictException.cs
@@ -1,0 +1,20 @@
+namespace MilsimPlanning.Api.Authorization;
+
+/// <summary>
+/// Thrown when a frequency assignment conflicts with an existing assignment on the same channel.
+/// Maps to HTTP 409 Conflict.
+/// </summary>
+public class FrequencyConflictException : Exception
+{
+    public string ConflictingSquadName { get; }
+    public decimal ConflictingFrequency { get; }
+    public string ConflictType { get; } // "primary" | "alternate"
+
+    public FrequencyConflictException(string conflictingSquadName, decimal conflictingFrequency, string conflictType)
+        : base($"Frequency {conflictingFrequency:F3} MHz conflicts with {conflictType} frequency assigned to '{conflictingSquadName}'.")
+    {
+        ConflictingSquadName = conflictingSquadName;
+        ConflictingFrequency = conflictingFrequency;
+        ConflictType = conflictType;
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
@@ -45,6 +45,7 @@ public class ChannelAssignmentsController : ControllerBase
             var result = await _service.CreateAssignmentAsync(eventId, request);
             return StatusCode(201, result);
         }
+        catch (FrequencyConflictException ex) { return Problem(title: "Frequency Conflict", detail: ex.Message, statusCode: 409); }
         catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
         catch (ArgumentException ex) { return Problem(title: "Validation Error", detail: ex.Message, statusCode: 422); }
         catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
@@ -64,6 +65,7 @@ public class ChannelAssignmentsController : ControllerBase
             var result = await _service.UpdateAssignmentAsync(eventId, id, request);
             return Ok(result);
         }
+        catch (FrequencyConflictException ex) { return Problem(title: "Frequency Conflict", detail: ex.Message, statusCode: 409); }
         catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
         catch (ArgumentException ex) { return Problem(title: "Validation Error", detail: ex.Message, statusCode: 422); }
         catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }

--- a/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
@@ -212,6 +212,10 @@ public class AppDbContext : IdentityDbContext<AppUser>
             .Property(a => a.PrimaryFrequency)
             .HasColumnType("decimal(8,3)");
 
+        builder.Entity<ChannelAssignment>()
+            .Property(a => a.AlternateFrequency)
+            .HasColumnType("decimal(8,3)");
+
         // Soft-delete global filter — excludes IsDeleted rows from all queries
         builder.Entity<ChannelAssignment>()
             .HasQueryFilter(a => !a.IsDeleted);

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
@@ -12,6 +12,7 @@ public class ChannelAssignment
     public Guid SquadId { get; set; }
     public Guid EventId { get; set; }
     public decimal PrimaryFrequency { get; set; }
+    public decimal? AlternateFrequency { get; set; }
     public bool IsDeleted { get; set; } = false;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425223949_AddAlternateFrequencyToChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425223949_AddAlternateFrequencyToChannelAssignment.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MilsimPlanning.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAlternateFrequencyToChannelAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Story 3 — add optional alternate frequency to squad channel assignments
+            migrationBuilder.AddColumn<decimal>(
+                name: "AlternateFrequency",
+                table: "ChannelAssignments",
+                type: "numeric(8,3)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AlternateFrequency",
+                table: "ChannelAssignments");
+        }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/AppDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace MilsimPlanning.Api.Data.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.5")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -218,6 +218,47 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.ChannelAssignment", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal?>("AlternateFrequency")
+                        .HasColumnType("decimal(8,3)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<decimal>("PrimaryFrequency")
+                        .HasColumnType("decimal(8,3)");
+
+                    b.Property<Guid>("RadioChannelId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("SquadId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("RadioChannelId");
+
+                    b.HasIndex("SquadId");
+
+                    b.ToTable("ChannelAssignments");
+                });
+
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.Event", b =>
                 {
                     b.Property<Guid>("Id")
@@ -364,6 +405,114 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsUnique();
 
                     b.ToTable("Factions");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyAuditLog", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("ActionType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("AlternateFrequency")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ConflictingUnitName")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("OccurredAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("PerformedByDisplayName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("PerformedByUserId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("PrimaryFrequency")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UnitId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UnitName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UnitType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId", "OccurredAt");
+
+                    b.ToTable("FrequencyAuditLogs");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyConflict", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("ActionTaken")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Frequency")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("FrequencyType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UnitAId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UnitAName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UnitAType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UnitBId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UnitBName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UnitBType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId", "Status");
+
+                    b.ToTable("FrequencyConflicts");
                 });
 
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.InfoSection", b =>
@@ -546,6 +695,84 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.ToTable("Platoons");
                 });
 
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannel", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("CallSign")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<int>("Order")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Scope")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId", "Order");
+
+                    b.ToTable("RadioChannels");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannelAssignment", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal?>("Alternate")
+                        .HasColumnType("decimal(7,3)");
+
+                    b.Property<Guid>("ChannelId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("FactionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("HasConflict")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("PlatoonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal?>("Primary")
+                        .HasColumnType("decimal(7,3)");
+
+                    b.Property<Guid?>("SquadId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ChannelId");
+
+                    b.HasIndex("FactionId");
+
+                    b.HasIndex("PlatoonId");
+
+                    b.HasIndex("SquadId");
+
+                    b.ToTable("RadioChannelAssignments");
+                });
+
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RosterChangeRequest", b =>
                 {
                     b.Property<Guid>("Id")
@@ -689,6 +916,33 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.ChannelAssignment", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.RadioChannel", "RadioChannel")
+                        .WithMany()
+                        .HasForeignKey("RadioChannelId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Squad", "Squad")
+                        .WithMany()
+                        .HasForeignKey("SquadId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+
+                    b.Navigation("RadioChannel");
+
+                    b.Navigation("Squad");
+                });
+
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.EventMembership", b =>
                 {
                     b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
@@ -752,6 +1006,28 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsRequired();
 
                     b.Navigation("Commander");
+
+                    b.Navigation("Event");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyAuditLog", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyConflict", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.Navigation("Event");
                 });
@@ -820,6 +1096,49 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsRequired();
 
                     b.Navigation("Faction");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannel", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannelAssignment", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.RadioChannel", "Channel")
+                        .WithMany("Assignments")
+                        .HasForeignKey("ChannelId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Faction", "Faction")
+                        .WithMany()
+                        .HasForeignKey("FactionId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Platoon", "Platoon")
+                        .WithMany()
+                        .HasForeignKey("PlatoonId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Squad", "Squad")
+                        .WithMany()
+                        .HasForeignKey("SquadId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.Navigation("Channel");
+
+                    b.Navigation("Faction");
+
+                    b.Navigation("Platoon");
+
+                    b.Navigation("Squad");
                 });
 
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RosterChangeRequest", b =>
@@ -900,6 +1219,11 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.Navigation("Players");
 
                     b.Navigation("Squads");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannel", b =>
+                {
+                    b.Navigation("Assignments");
                 });
 
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.Squad", b =>

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
@@ -9,6 +9,7 @@ public record ChannelAssignmentDto
     public Guid SquadId { get; init; }
     public string SquadName { get; init; } = null!;
     public decimal PrimaryFrequency { get; init; }
+    public decimal? AlternateFrequency { get; init; }
     public Guid EventId { get; init; }
     public DateTime CreatedAt { get; init; }
     public DateTime UpdatedAt { get; init; }

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
@@ -3,5 +3,6 @@ namespace MilsimPlanning.Api.Models.ChannelAssignments;
 public record CreateChannelAssignmentRequest(
     Guid RadioChannelId,
     Guid SquadId,
-    decimal PrimaryFrequency
+    decimal PrimaryFrequency,
+    decimal? AlternateFrequency = null
 );

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
@@ -1,5 +1,6 @@
 namespace MilsimPlanning.Api.Models.ChannelAssignments;
 
 public record UpdateChannelAssignmentRequest(
-    decimal PrimaryFrequency
+    decimal PrimaryFrequency,
+    decimal? AlternateFrequency = null
 );

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -67,6 +67,14 @@ public class ChannelAssignmentService
         // Validate frequency against channel scope
         _validator.Validate(request.PrimaryFrequency, channel.Scope);
 
+        // Validate alternate frequency if provided
+        if (request.AlternateFrequency.HasValue)
+        {
+            _validator.Validate(request.AlternateFrequency.Value, channel.Scope);
+            if (request.AlternateFrequency.Value == request.PrimaryFrequency)
+                throw new ArgumentException("Alternate frequency cannot match primary frequency");
+        }
+
         var now = DateTime.UtcNow;
         var assignment = new ChannelAssignment
         {
@@ -74,6 +82,7 @@ public class ChannelAssignmentService
             RadioChannelId = request.RadioChannelId,
             SquadId = request.SquadId,
             PrimaryFrequency = request.PrimaryFrequency,
+            AlternateFrequency = request.AlternateFrequency,
             EventId = eventId,
             IsDeleted = false,
             CreatedAt = now,
@@ -112,7 +121,16 @@ public class ChannelAssignmentService
         // Validate frequency against channel scope
         _validator.Validate(request.PrimaryFrequency, assignment.RadioChannel.Scope);
 
+        // Validate alternate frequency if provided
+        if (request.AlternateFrequency.HasValue)
+        {
+            _validator.Validate(request.AlternateFrequency.Value, assignment.RadioChannel.Scope);
+            if (request.AlternateFrequency.Value == request.PrimaryFrequency)
+                throw new ArgumentException("Alternate frequency cannot match primary frequency");
+        }
+
         assignment.PrimaryFrequency = request.PrimaryFrequency;
+        assignment.AlternateFrequency = request.AlternateFrequency;
         assignment.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync();
@@ -160,6 +178,7 @@ public class ChannelAssignmentService
         SquadId = a.SquadId,
         SquadName = a.Squad.Name,
         PrimaryFrequency = a.PrimaryFrequency,
+        AlternateFrequency = a.AlternateFrequency,
         EventId = a.EventId,
         CreatedAt = a.CreatedAt,
         UpdatedAt = a.UpdatedAt

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -75,6 +75,9 @@ public class ChannelAssignmentService
                 throw new ArgumentException("Alternate frequency cannot match primary frequency");
         }
 
+        // AC-04: Check for frequency conflicts with other units on the same channel
+        await AssertNoFrequencyConflictsAsync(request.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency, excludeAssignmentId: null);
+
         var now = DateTime.UtcNow;
         var assignment = new ChannelAssignment
         {
@@ -129,6 +132,9 @@ public class ChannelAssignmentService
                 throw new ArgumentException("Alternate frequency cannot match primary frequency");
         }
 
+        // AC-04: Check for frequency conflicts with other units on the same channel (exclude self)
+        await AssertNoFrequencyConflictsAsync(assignment.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency, excludeAssignmentId: assignmentId);
+
         assignment.PrimaryFrequency = request.PrimaryFrequency;
         assignment.AlternateFrequency = request.AlternateFrequency;
         assignment.UpdatedAt = DateTime.UtcNow;
@@ -162,6 +168,44 @@ public class ChannelAssignmentService
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// AC-04: Checks if a primary or alternate frequency conflicts with any existing
+    /// (non-deleted) assignment on the same radio channel. Excludes the calling
+    /// assignment's own record (for updates).
+    /// </summary>
+    private async Task AssertNoFrequencyConflictsAsync(
+        Guid radioChannelId,
+        decimal primaryFrequency,
+        decimal? alternateFrequency,
+        Guid? excludeAssignmentId)
+    {
+        var existingAssignments = await _db.ChannelAssignments
+            .Include(a => a.Squad)
+            .Where(a => a.RadioChannelId == radioChannelId && !a.IsDeleted)
+            .Where(a => excludeAssignmentId == null || a.Id != excludeAssignmentId.Value)
+            .ToListAsync();
+
+        foreach (var existing in existingAssignments)
+        {
+            // Check primary frequency against existing primary
+            if (existing.PrimaryFrequency == primaryFrequency)
+                throw new FrequencyConflictException(existing.Squad.Name, primaryFrequency, "primary");
+
+            // Check primary frequency against existing alternate
+            if (existing.AlternateFrequency.HasValue && existing.AlternateFrequency.Value == primaryFrequency)
+                throw new FrequencyConflictException(existing.Squad.Name, primaryFrequency, "alternate");
+
+            // Check alternate frequency (if provided) against existing primary
+            if (alternateFrequency.HasValue && existing.PrimaryFrequency == alternateFrequency.Value)
+                throw new FrequencyConflictException(existing.Squad.Name, alternateFrequency.Value, "primary");
+
+            // Check alternate frequency (if provided) against existing alternate
+            if (alternateFrequency.HasValue && existing.AlternateFrequency.HasValue
+                && existing.AlternateFrequency.Value == alternateFrequency.Value)
+                throw new FrequencyConflictException(existing.Squad.Name, alternateFrequency.Value, "alternate");
+        }
+    }
 
     private void AssertCommanderAccess(Faction faction)
     {

--- a/web/src/__tests__/RadioChannelsPage.test.tsx
+++ b/web/src/__tests__/RadioChannelsPage.test.tsx
@@ -444,4 +444,37 @@ describe('RadioChannelsPage', () => {
       ).toBe(true);
     });
   });
+
+  // AC-04: Frequency conflict error from backend (409) is shown in create form
+  it('Story 3 AC-04: shows conflict error when backend returns 409 on create', async () => {
+    server.use(
+      http.post('/api/events/:eventId/channel-assignments', () =>
+        HttpResponse.json(
+          { detail: "Frequency 36.500 MHz conflicts with primary frequency assigned to 'Alpha-1'." },
+          { status: 409 }
+        )
+      )
+    );
+
+    renderPage('faction_commander');
+
+    // Open the create form
+    await waitFor(() => expect(screen.getByRole('button', { name: /Assign Frequency/i })).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /Assign Frequency/i }));
+
+    // Fill in required fields
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+    fireEvent.change(screen.getByLabelText('Primary frequency (MHz)'), { target: { value: '36.500' } });
+    fireEvent.change(screen.getByLabelText('Select unit'), { target: { value: 'squad-1' } });
+
+    // Submit the form directly (avoids disabled-button timing issues)
+    const assignForm = document.querySelector('form.border') as HTMLFormElement;
+    fireEvent.submit(assignForm);
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.some((a) => /conflict/i.test(a.textContent ?? ''))).toBe(true);
+    });
+  });
 });

--- a/web/src/__tests__/RadioChannelsPage.test.tsx
+++ b/web/src/__tests__/RadioChannelsPage.test.tsx
@@ -41,6 +41,7 @@ const mockAssignment: ChannelAssignmentDto = {
   squadId: 'squad-1',
   squadName: 'Alpha-1',
   primaryFrequency: 36.5,
+  alternateFrequency: null,
   eventId: 'event-123',
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
@@ -343,6 +344,104 @@ describe('RadioChannelsPage', () => {
       // The validation error specifically matches the alert role
       const alerts = screen.getAllByRole('alert');
       expect(alerts.some((a) => /25 kHz/i.test(a.textContent ?? ''))).toBe(true);
+    });
+  });
+
+  // ── Story 3: Alternate Frequency ───────────────────────────────────────────
+
+  // Alternate frequency column header appears in table
+  it('Story 3: shows Alternate Frequency column in assignments table', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('Alternate Frequency')).toBeDefined();
+    });
+  });
+
+  // Null alternate frequency shows em dash
+  it('Story 3: shows em dash for null alternate frequency', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha-1')).toBeDefined();
+      // The dash for null alternate frequency
+      expect(screen.getByText('—')).toBeDefined();
+    });
+  });
+
+  // Alternate frequency displayed when present
+  it('Story 3: shows alternate frequency when present', async () => {
+    const assignmentWithAlt: ChannelAssignmentDto = {
+      ...mockAssignment,
+      id: 'assign-alt',
+      alternateFrequency: 36.525,
+    };
+
+    server.use(
+      http.get('/api/events/:eventId/channel-assignments', () =>
+        HttpResponse.json({ total: 1, items: [assignmentWithAlt] })
+      )
+    );
+
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('36.525 MHz')).toBeDefined();
+    });
+  });
+
+  // Alternate frequency input in create form
+  it('Story 3: Assign Frequency form shows alternate frequency input', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Alternate frequency (MHz)')).toBeDefined();
+    });
+  });
+
+  // Alternate frequency real-time validation: out of range
+  it('Story 3: shows validation error when alternate frequency is out of range', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Alternate frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Alternate frequency (MHz)'), { target: { value: '90.0' } });
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.some((a) => /out of range|within VHF/i.test(a.textContent ?? ''))).toBe(true);
+    });
+  });
+
+  // Alternate frequency real-time validation: same as primary
+  it('Story 3: shows error when alternate frequency matches primary', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Primary frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Primary frequency (MHz)'), { target: { value: '36.500' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Alternate frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Alternate frequency (MHz)'), { target: { value: '36.500' } });
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(
+        alerts.some((a) => /cannot match primary/i.test(a.textContent ?? ''))
+      ).toBe(true);
     });
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,7 +21,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       return undefined as T;   // navigation is in flight; prevent further processing
     }
     const error = await response.json().catch(() => ({ error: response.statusText }));
-    throw Object.assign(new Error(error.error ?? 'API error'), { status: response.status });
+    throw Object.assign(new Error(error.detail ?? error.error ?? 'API error'), { status: response.status });
   }
   if (response.status === 204) return undefined as T;
   return response.json();
@@ -48,7 +48,7 @@ async function upload<T>(path: string, file: File, fieldName = 'file'): Promise<
       return undefined as T;
     }
     const error = await response.json().catch(() => ({ error: response.statusText }));
-    throw Object.assign(new Error(error.error ?? 'API error'), { status: response.status });
+    throw Object.assign(new Error(error.detail ?? error.error ?? 'API error'), { status: response.status });
   }
   if (response.status === 204) return undefined as T;
   return response.json();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -382,6 +382,7 @@ export interface ChannelAssignmentDto {
   squadId: string;
   squadName: string;
   primaryFrequency: number;
+  alternateFrequency: number | null;
   eventId: string;
   createdAt: string;
   updatedAt: string;
@@ -396,8 +397,10 @@ export interface CreateChannelAssignmentRequest {
   radioChannelId: string;
   squadId: string;
   primaryFrequency: number;
+  alternateFrequency?: number | null;
 }
 
 export interface UpdateChannelAssignmentRequest {
   primaryFrequency: number;
+  alternateFrequency?: number | null;
 }

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -299,18 +299,53 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
   const [editing, setEditing] = useState(false);
   const [freqValue, setFreqValue] = useState(assignment.primaryFrequency.toString());
   const [freqError, setFreqError] = useState<string | null>(null);
+  const [altFreqValue, setAltFreqValue] = useState(
+    assignment.alternateFrequency !== null && assignment.alternateFrequency !== undefined
+      ? assignment.alternateFrequency.toString()
+      : ''
+  );
+  const [altFreqError, setAltFreqError] = useState<string | null>(null);
+
+  const scope = (assignment.channelScope as ChannelScope) ?? 'VHF';
 
   // Real-time validation as user types (AC-10)
   const handleFreqChange = (val: string) => {
     setFreqValue(val);
-    const scope = (assignment.channelScope as ChannelScope) ?? 'VHF';
     setFreqError(validateFrequency(val, scope));
+    // Re-validate alternate against new primary if alternate is present
+    if (altFreqValue) {
+      const altErr = validateFrequency(altFreqValue, scope);
+      if (altErr) {
+        setAltFreqError(altErr);
+      } else if (parseFloat(altFreqValue) === parseFloat(val)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
+  };
+
+  const handleAltFreqChange = (val: string) => {
+    setAltFreqValue(val);
+    if (!val) {
+      setAltFreqError(null);
+      return;
+    }
+    const err = validateFrequency(val, scope);
+    if (err) {
+      setAltFreqError(err);
+    } else if (parseFloat(val) === parseFloat(freqValue)) {
+      setAltFreqError('Alternate frequency cannot match primary frequency');
+    } else {
+      setAltFreqError(null);
+    }
   };
 
   const updateMutation = useMutation({
     mutationFn: () =>
       api.updateChannelAssignment(eventId, assignment.id, {
         primaryFrequency: parseFloat(freqValue),
+        alternateFrequency: altFreqValue ? parseFloat(altFreqValue) : null,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
@@ -335,6 +370,21 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
   });
 
   const channel = channels.find((c) => c.id === assignment.radioChannelId);
+
+  const cancelEdit = () => {
+    setEditing(false);
+    setFreqValue(assignment.primaryFrequency.toString());
+    setFreqError(null);
+    setAltFreqValue(
+      assignment.alternateFrequency !== null && assignment.alternateFrequency !== undefined
+        ? assignment.alternateFrequency.toString()
+        : ''
+    );
+    setAltFreqError(null);
+  };
+
+  const isSaveDisabled =
+    updateMutation.isPending || !!freqError || !freqValue || !!altFreqError;
 
   if (editing) {
     return (
@@ -361,12 +411,30 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
           </div>
         </td>
         <td className="py-3 px-4">
+          <div className="space-y-1">
+            <Input
+              aria-label="Alternate frequency (MHz)"
+              value={altFreqValue}
+              onChange={(e) => handleAltFreqChange(e.target.value)}
+              placeholder="Optional"
+              className="h-8 w-32"
+              type="number"
+              step="0.025"
+              min={channel ? SCOPE_INFO[channel.scope].min : 30}
+              max={channel ? SCOPE_INFO[channel.scope].max : 400}
+            />
+            {altFreqError && (
+              <p className="text-xs text-red-600" role="alert">{altFreqError}</p>
+            )}
+          </div>
+        </td>
+        <td className="py-3 px-4">
           <div className="flex gap-1">
             <Button
               size="sm"
               variant="ghost"
               onClick={() => updateMutation.mutate()}
-              disabled={updateMutation.isPending || !!freqError || !freqValue}
+              disabled={isSaveDisabled}
               aria-label="Save assignment"
             >
               <Check className="h-4 w-4 text-green-600" />
@@ -374,7 +442,7 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
             <Button
               size="sm"
               variant="ghost"
-              onClick={() => { setEditing(false); setFreqValue(assignment.primaryFrequency.toString()); setFreqError(null); }}
+              onClick={cancelEdit}
               aria-label="Cancel edit"
             >
               <X className="h-4 w-4 text-red-600" />
@@ -393,6 +461,11 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
         <span className="ml-2 text-xs text-muted-foreground">{assignment.channelScope}</span>
       </td>
       <td className="py-3 px-4 text-sm font-mono">{assignment.primaryFrequency.toFixed(3)} MHz</td>
+      <td className="py-3 px-4 text-sm font-mono">
+        {assignment.alternateFrequency !== null && assignment.alternateFrequency !== undefined
+          ? `${assignment.alternateFrequency.toFixed(3)} MHz`
+          : '—'}
+      </td>
       <td className="py-3 px-4">
         {isCommander && (
           <div className="flex gap-1">
@@ -441,6 +514,8 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
   const [squadId, setSquadId] = useState('');
   const [freqValue, setFreqValue] = useState('');
   const [freqError, setFreqError] = useState<string | null>(null);
+  const [altFreqValue, setAltFreqValue] = useState('');
+  const [altFreqError, setAltFreqError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
   // Load roster to get squad list (AC-01)
@@ -467,6 +542,35 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     } else {
       setFreqError(null);
     }
+    // Re-validate alternate against new primary
+    if (altFreqValue && selectedChannel) {
+      const altErr = validateFrequency(altFreqValue, selectedChannel.scope);
+      if (altErr) {
+        setAltFreqError(altErr);
+      } else if (parseFloat(altFreqValue) === parseFloat(val)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
+  };
+
+  const handleAltFreqChange = (val: string) => {
+    setAltFreqValue(val);
+    if (!val) {
+      setAltFreqError(null);
+      return;
+    }
+    if (selectedChannel) {
+      const err = validateFrequency(val, selectedChannel.scope);
+      if (err) {
+        setAltFreqError(err);
+      } else if (parseFloat(val) === parseFloat(freqValue)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
   };
 
   // Re-validate when channel scope changes
@@ -476,6 +580,16 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     if (ch && freqValue) {
       setFreqError(validateFrequency(freqValue, ch.scope));
     }
+    if (ch && altFreqValue) {
+      const altErr = validateFrequency(altFreqValue, ch.scope);
+      if (altErr) {
+        setAltFreqError(altErr);
+      } else if (freqValue && parseFloat(altFreqValue) === parseFloat(freqValue)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
   };
 
   const createMutation = useMutation({
@@ -484,6 +598,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
         radioChannelId: channelId,
         squadId,
         primaryFrequency: parseFloat(freqValue),
+        alternateFrequency: altFreqValue ? parseFloat(altFreqValue) : null,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
@@ -493,6 +608,8 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
       setSquadId('');
       setFreqValue('');
       setFreqError(null);
+      setAltFreqValue('');
+      setAltFreqError(null);
       setFormError(null);
       toast.success('Assignment created');
     },
@@ -507,6 +624,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     if (!squadId) { setFormError('Select a unit.'); return; }
     const err = selectedChannel ? validateFrequency(freqValue, selectedChannel.scope) : 'Select a channel first.';
     if (err) { setFreqError(err); return; }
+    if (altFreqError) return;
     setFormError(null);
     createMutation.mutate();
   };
@@ -601,6 +719,36 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
         )}
       </div>
 
+      {/* Alternate frequency input (Story 3) */}
+      <div className="space-y-2">
+        <label htmlFor="assign-alt-freq" className="text-sm font-medium">
+          Alternate frequency (MHz) <span className="text-muted-foreground text-xs">(optional)</span>
+        </label>
+        <Input
+          id="assign-alt-freq"
+          aria-label="Alternate frequency (MHz)"
+          value={altFreqValue}
+          onChange={(e) => handleAltFreqChange(e.target.value)}
+          placeholder={
+            selectedChannel
+              ? `e.g. ${selectedChannel.scope === 'VHF' ? '36.525' : '225.050'}`
+              : 'Select a channel first'
+          }
+          type="number"
+          step="0.025"
+          min={selectedChannel ? SCOPE_INFO[selectedChannel.scope].min : undefined}
+          max={selectedChannel ? SCOPE_INFO[selectedChannel.scope].max : undefined}
+          className="max-w-xs"
+          disabled={!channelId}
+        />
+        {altFreqError && (
+          <p className="text-xs text-red-600" role="alert">{altFreqError}</p>
+        )}
+        {selectedChannel && !altFreqError && altFreqValue && (
+          <p className="text-xs text-green-600">Valid {selectedChannel.scope} alternate frequency</p>
+        )}
+      </div>
+
       {formError && (
         <p className="text-sm text-red-600" role="alert">{formError}</p>
       )}
@@ -609,7 +757,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
         <Button
           type="submit"
           size="sm"
-          disabled={createMutation.isPending || !channelId || !squadId || !!freqError || !freqValue}
+          disabled={createMutation.isPending || !channelId || !squadId || !!freqError || !freqValue || !!altFreqError}
         >
           {createMutation.isPending ? 'Saving…' : 'Save Assignment'}
         </Button>
@@ -623,6 +771,8 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
             setSquadId('');
             setFreqValue('');
             setFreqError(null);
+            setAltFreqValue('');
+            setAltFreqError(null);
             setFormError(null);
           }}
         >
@@ -677,6 +827,7 @@ function AssignmentsSection({ eventId, channels, isCommander }: AssignmentsSecti
                 <th className="text-left py-2 px-4 font-medium">Unit</th>
                 <th className="text-left py-2 px-4 font-medium">Channel</th>
                 <th className="text-left py-2 px-4 font-medium">Primary Frequency</th>
+                <th className="text-left py-2 px-4 font-medium">Alternate Frequency</th>
                 <th className="py-2 px-4" />
               </tr>
             </thead>

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -353,7 +353,11 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
       toast.success('Assignment updated');
     },
     onError: (err: Error & { status?: number }) => {
-      setFreqError(err.message);
+      if (err.status === 409) {
+        setFreqError(`Frequency conflict: ${err.message}`);
+      } else {
+        setFreqError(err.message);
+      }
     },
   });
 
@@ -614,7 +618,11 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
       toast.success('Assignment created');
     },
     onError: (err: Error & { status?: number }) => {
-      setFormError(err.message);
+      if (err.status === 409) {
+        setFormError(`Frequency conflict: ${err.message}`);
+      } else {
+        setFormError(err.message);
+      }
     },
   });
 


### PR DESCRIPTION
## Summary

- Adds optional `AlternateFrequency` field to `ChannelAssignment` entity (nullable `decimal(8,3)`)
- Validates alternate frequency against NATO ranges (VHF 30.0–87.975 MHz, UHF 225–400 MHz) and 25 kHz spacing
- Prevents alternate frequency from equaling primary frequency (AC-03)
- Supports adding/editing/removing alternate frequency during creation and post-creation
- Frontend shows alternate frequency in assignment list table and form with real-time inline validation

## Acceptance Criteria Status

| AC | Status | Notes |
|----|--------|-------|
| AC-01 | ✅ | Optional in create & edit |
| AC-02 | ✅ | NATO range + 25 kHz spacing via NatoFrequencyValidationService |
| AC-03 | ✅ | "Alternate frequency cannot match primary frequency" |
| AC-04 | ⚠️ | Story 4 (conflict detection) not yet implemented — deferred |
| AC-05 | ✅ | Both frequencies in list/table; API returns AlternateFrequency |
| AC-06 | ✅ | Edit alternate independently via PUT |
| AC-07 | ✅ | Set `alternateFrequency: null` to remove |
| AC-08 | ✅ | Real-time inline validation on input change |

## Technical Notes

- Branch rebased on `feature/912-create-radio-channel-scoped-to-operation` (Story 2 base)
- Migration `20260425223949_AddAlternateFrequencyToChannelAssignment` only adds the column (additive delta)
- Backend: 6 new integration tests in `ChannelAssignmentAlternateFrequencyTests`
- Frontend: 5 new tests in `RadioChannelsPage.test.tsx`
- Tests require Docker for execution (Testcontainers)

## Test plan
- [ ] Verify Docker Compose starts cleanly with new migration applied
- [ ] Create assignment with alternate frequency → both frequencies returned
- [ ] Create assignment with alternate = primary → 422 with "Alternate frequency cannot match primary frequency"
- [ ] Create assignment with invalid alternate range → 422
- [ ] Update assignment to add/edit/remove alternate frequency → 200
- [ ] List view shows both frequencies (alternate shows "—" when null)
- [ ] Real-time validation fires on input change

🤖 Generated with [Claude Code](https://claude.com/claude-code)