### PR TITLE
[#911] Story 4: Detect and warn of frequency conflicts

### DIFF
--- a/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
@@ -659,4 +659,87 @@ public class ChannelAssignmentConflictDetectionTests : ChannelAssignmentTestsBas
 
         second.StatusCode.Should().Be(HttpStatusCode.Created);
     }
+
+    // ── AC-04: Advisory mode override ─────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAssignment_WithOverrideConflict_Returns201WithHasConflictTrue()
+    {
+        // First assignment occupies frequency 72.500
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 72.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad — same frequency but user overrides the advisory warning
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-Override", Order = 20 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 72.500m, overrideConflict = true });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("hasConflict").GetBoolean().Should().BeTrue("overridden conflict should be persisted as hasConflict=true");
+    }
+
+    // ── AC-05: Clean assignment has hasConflict=false ──────────────────────────
+
+    [Fact]
+    public async Task CreateAssignment_NoConflict_ReturnsHasConflictFalse()
+    {
+        var create = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 74.500m });
+
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await create.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("hasConflict").GetBoolean().Should().BeFalse("a clean assignment should have hasConflict=false");
+    }
+
+    // ── AC-07: GET /channel-assignments/conflicts returns conflict summary ─────
+
+    [Fact]
+    public async Task GetConflicts_ReturnsConflictSummaryWithConflictingUnits()
+    {
+        // Create first assignment
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 76.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Create second squad
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-Conflict-Summary", Order = 21 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        // Create conflicting assignment with override
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 76.500m, overrideConflict = true });
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Fetch conflict summary
+        var summary = await _commanderClient.GetAsync($"/api/events/{_eventId}/channel-assignments/conflicts");
+        summary.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await summary.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("conflictCount").GetInt32().Should().BeGreaterThan(0, "there should be at least one conflict");
+
+        var conflicts = body.GetProperty("conflicts").EnumerateArray().ToList();
+        conflicts.Should().NotBeEmpty();
+
+        var first_conflict = conflicts.First();
+        first_conflict.TryGetProperty("squadName", out _).Should().BeTrue();
+        first_conflict.TryGetProperty("conflictingSquadName", out _).Should().BeTrue();
+        first_conflict.TryGetProperty("conflictingFrequency", out _).Should().BeTrue();
+    }
 }

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
@@ -505,3 +505,158 @@ public class ChannelAssignmentAlternateFrequencyTests : ChannelAssignmentTestsBa
         updated.GetProperty("alternateFrequency").ValueKind.Should().Be(JsonValueKind.Null);
     }
 }
+
+// ── AC-04: Frequency conflict detection tests ──────────────────────────────────
+
+[Trait("Category", "ChannelAssignment_ConflictDetection")]
+public class ChannelAssignmentConflictDetectionTests : ChannelAssignmentTestsBase
+{
+    public ChannelAssignmentConflictDetectionTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task CreateAssignment_DuplicatePrimaryFrequency_Returns409()
+    {
+        // First assignment succeeds
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 60.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad tries the same primary frequency on the same channel
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-2", Order = 2 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 60.500m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("60.500");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_PrimaryConflictsWithExistingAlternate_Returns409()
+    {
+        // First assignment with primary + alternate
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 62.500m, alternateFrequency = 62.525m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad tries primary that matches first squad's alternate
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-3", Order = 3 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 62.525m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("62.525");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_AlternateConflictsWithExistingPrimary_Returns409()
+    {
+        // First assignment
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 64.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second squad tries alternate that matches first squad's primary
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-4", Order = 4 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 64.525m, alternateFrequency = 64.500m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("64.500");
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_ConflictsWithOtherUnit_Returns409()
+    {
+        // Create two assignments with different frequencies
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 66.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var squad2Id = Guid.NewGuid();
+        var squad2 = new Squad { Id = squad2Id, PlatoonId = _platoonId, Name = "Alpha-5", Order = 5 };
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        db.Squads.Add(squad2);
+        await db.SaveChangesAsync();
+
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = squad2Id, primaryFrequency = 66.525m });
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+        var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        var secondId = secondBody.GetProperty("id").GetGuid();
+
+        // Try to update second to match first's frequency
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{secondId}",
+            new { primaryFrequency = 66.500m });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("66.500");
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_SameFrequency_NoConflictWithSelf_Returns200()
+    {
+        // Create assignment
+        var create = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 68.500m });
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await create.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update with same frequency — should not conflict with itself
+        var update = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 68.500m });
+
+        update.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_SameFrequencyDifferentChannel_Returns201()
+    {
+        // Assign on VHF channel
+        var first = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 70.500m });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Same squad, different channel — no conflict
+        var second = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelUhfId, squadId = _squadId, primaryFrequency = 225.025m });
+
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
@@ -1,0 +1,401 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Services;
+using MilsimPlanning.Api.Tests.Fixtures;
+using Moq;
+using Xunit;
+
+namespace MilsimPlanning.Api.Tests.ChannelAssignments;
+
+/// <summary>
+/// Integration tests for ChannelAssignment CRUD API.
+/// Covers AC-04 (NATO range), AC-05 (25 kHz spacing), AC-07 (persistence),
+/// AC-08 (list), AC-09 (edit/delete), auth, and IDOR.
+/// </summary>
+public class ChannelAssignmentTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+{
+    protected readonly PostgreSqlFixture _fixture;
+    protected WebApplicationFactory<Program> _factory = null!;
+    protected Mock<IEmailService> _emailMock = null!;
+    protected HttpClient _commanderClient = null!;
+    protected HttpClient _playerClient = null!;
+    protected Guid _eventId;
+    protected Guid _factionId;
+    protected Guid _platoonId;
+    protected Guid _squadId;
+    protected Guid _channelVhfId;
+    protected Guid _channelUhfId;
+    protected string _commanderUserId = string.Empty;
+    protected string _playerUserId = string.Empty;
+
+    public ChannelAssignmentTestsBase(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _emailMock = new Mock<IEmailService>();
+        _emailMock.Setup(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(Task.CompletedTask);
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Jwt:Secret"] = "dev-placeholder-secret-32-chars!!",
+                        ["Jwt:Issuer"] = "milsim-tests",
+                        ["Jwt:Audience"] = "milsim-tests"
+                    });
+                });
+
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<DbContextOptions<AppDbContext>>();
+                    services.RemoveAll<AppDbContext>();
+                    services.AddDbContext<AppDbContext>(opts =>
+                        opts.UseNpgsql(_fixture.ConnectionString));
+
+                    services.RemoveAll<IEmailService>();
+                    services.AddSingleton(_emailMock.Object);
+
+                    services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = IntegrationTestAuthHandler.SchemeName;
+                        options.DefaultChallengeScheme = IntegrationTestAuthHandler.SchemeName;
+                    }).AddScheme<AuthenticationSchemeOptions, IntegrationTestAuthHandler>(IntegrationTestAuthHandler.SchemeName, _ => { });
+                });
+            });
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.MigrateAsync();
+
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        foreach (var role in new[] { "player", "squad_leader", "platoon_leader", "faction_commander", "system_admin" })
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+                await roleManager.CreateAsync(new IdentityRole(role));
+        }
+
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+
+        // Commander
+        var cmdEmail = $"ca-cmdr-{Guid.NewGuid():N}@test.com";
+        var commander = new AppUser { UserName = cmdEmail, Email = cmdEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(commander, "TestPass123!");
+        await userManager.AddToRoleAsync(commander, "faction_commander");
+        commander.Profile = new UserProfile { UserId = commander.Id, Callsign = "Commander", DisplayName = "Commander", User = commander };
+        _commanderUserId = commander.Id;
+
+        // Player
+        var playerEmail = $"ca-player-{Guid.NewGuid():N}@test.com";
+        var player = new AppUser { UserName = playerEmail, Email = playerEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(player, "TestPass123!");
+        await userManager.AddToRoleAsync(player, "player");
+        player.Profile = new UserProfile { UserId = player.Id, Callsign = "Player1", DisplayName = "Player1", User = player };
+        _playerUserId = player.Id;
+
+        // Seed event hierarchy
+        _eventId = Guid.NewGuid();
+        _factionId = Guid.NewGuid();
+        _platoonId = Guid.NewGuid();
+        _squadId = Guid.NewGuid();
+
+        var squad = new Squad { Id = _squadId, PlatoonId = _platoonId, Name = "Alpha-1", Order = 1 };
+        var platoon = new Platoon { Id = _platoonId, FactionId = _factionId, Name = "Alpha Platoon", Order = 1, Squads = [squad] };
+        var faction = new Faction { Id = _factionId, Name = "Blue Force", CommanderId = commander.Id, EventId = _eventId, Platoons = [platoon] };
+        var testEvent = new Event { Id = _eventId, Name = "CA Test Event", Status = EventStatus.Draft, FactionId = _factionId, Faction = faction };
+
+        db.Events.Add(testEvent);
+        await db.SaveChangesAsync();
+
+        db.EventMemberships.Add(new EventMembership { UserId = commander.Id, EventId = _eventId, Role = "faction_commander" });
+        db.EventMemberships.Add(new EventMembership { UserId = player.Id, EventId = _eventId, Role = "player" });
+        await db.SaveChangesAsync();
+
+        // Seed RadioChannels (bypassing soft-delete filter)
+        _channelVhfId = Guid.NewGuid();
+        _channelUhfId = Guid.NewGuid();
+
+        await db.RadioChannels.AddRangeAsync(
+            new RadioChannel { Id = _channelVhfId, EventId = _eventId, Name = "Command Net", Scope = ChannelScope.VHF, Order = 0 },
+            new RadioChannel { Id = _channelUhfId, EventId = _eventId, Name = "Air Net", Scope = ChannelScope.UHF, Order = 1 }
+        );
+        await db.SaveChangesAsync();
+
+        _commanderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_commanderClient, commander.Id, "faction_commander");
+        _playerClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_playerClient, player.Id, "player");
+    }
+
+    public Task DisposeAsync()
+    {
+        _commanderClient.Dispose();
+        _playerClient.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+}
+
+// ── Frequency validation tests (AC-04, AC-05) ─────────────────────────────────
+
+[Trait("Category", "ChannelAssignment_FrequencyValidation")]
+public class ChannelAssignmentFrequencyValidationTests : ChannelAssignmentTestsBase
+{
+    public ChannelAssignmentFrequencyValidationTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task CreateAssignment_VhfValidFrequency_Returns201()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 30.025m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("primaryFrequency").GetDecimal().Should().Be(30.025m);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_UhfValidFrequency_Returns201()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelUhfId, squadId = _squadId, primaryFrequency = 225.025m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_VhfOutOfRange_Returns422()
+    {
+        // 90.0 MHz is above VHF max of 87.975
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 90.0m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("out of range");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_UhfOutOfRange_Returns422()
+    {
+        // 100.0 MHz is below UHF min of 225
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelUhfId, squadId = _squadId, primaryFrequency = 100.0m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_InvalidSpacing_Returns422()
+    {
+        // 30.012 is not a multiple of 0.025
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 30.012m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("25 kHz");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_Boundary_VhfMax_Returns201()
+    {
+        // 87.975 is the VHF maximum — should succeed
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 87.975m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_Boundary_VhfMin_Returns201()
+    {
+        // 30.0 is the VHF minimum — should succeed
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 30.0m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+}
+
+// ── CRUD tests (AC-07, AC-08, AC-09) ─────────────────────────────────────────
+
+[Trait("Category", "ChannelAssignment_Crud")]
+public class ChannelAssignmentCrudTests : ChannelAssignmentTestsBase
+{
+    public ChannelAssignmentCrudTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task CreateAssignment_AsCommander_Returns201WithCorrectBody()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("radioChannelId").GetGuid().Should().Be(_channelVhfId);
+        body.GetProperty("squadId").GetGuid().Should().Be(_squadId);
+        body.GetProperty("primaryFrequency").GetDecimal().Should().Be(36.500m);
+        body.GetProperty("channelScope").GetString().Should().Be("VHF");
+    }
+
+    [Fact]
+    public async Task GetAssignments_AsPlayer_ReturnsAssignmentList()
+    {
+        // Create one assignment first
+        await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 40.025m });
+
+        var response = await _playerClient.GetAsync(
+            $"/api/events/{_eventId}/channel-assignments?limit=20&offset=0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
+        body.GetProperty("items").EnumerateArray().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_AsCommander_Returns200WithUpdatedFrequency()
+    {
+        // Create first
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 45.025m });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 45.050m });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        updated.GetProperty("primaryFrequency").GetDecimal().Should().Be(45.050m);
+    }
+
+    [Fact]
+    public async Task DeleteAssignment_AsCommander_Returns204()
+    {
+        // Create first
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 50.025m });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Delete
+        var deleteResponse = await _commanderClient.DeleteAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}");
+
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task DeleteAssignment_ThenGet_IsExcludedFromList()
+    {
+        // Create
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 55.025m });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Delete
+        await _commanderClient.DeleteAsync($"/api/events/{_eventId}/channel-assignments/{assignmentId}");
+
+        // Get and assert not in list
+        var listResponse = await _commanderClient.GetAsync($"/api/events/{_eventId}/channel-assignments");
+        var body = await listResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items").EnumerateArray().ToList();
+        items.Should().NotContain(i => i.GetProperty("id").GetGuid() == assignmentId);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_AsPlayer_Returns403()
+    {
+        var response = await _playerClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetAssignments_IDOR_Returns403ForOtherEvent()
+    {
+        var otherEventId = Guid.NewGuid();
+        var response = await _commanderClient.GetAsync($"/api/events/{otherEventId}/channel-assignments");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetAssignments_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var response = await anonClient.GetAsync($"/api/events/{_eventId}/channel-assignments");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        anonClient.Dispose();
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_WithInvalidFrequency_Returns422()
+    {
+        // Create valid assignment
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 60.025m });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update with invalid frequency
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 200.0m }); // out of VHF range
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_NonExistentChannel_Returns404()
+    {
+        var fakeChannelId = Guid.NewGuid();
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = fakeChannelId, squadId = _squadId, primaryFrequency = 36.500m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/ChannelAssignments/ChannelAssignmentTests.cs
@@ -399,3 +399,109 @@ public class ChannelAssignmentCrudTests : ChannelAssignmentTestsBase
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }
+
+// ── Alternate frequency tests (Story 3) ───────────────────────────────────────
+
+[Trait("Category", "ChannelAssignment_AlternateFrequency")]
+public class ChannelAssignmentAlternateFrequencyTests : ChannelAssignmentTestsBase
+{
+    public ChannelAssignmentAlternateFrequencyTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task CreateAssignment_WithAlternateFrequency_Returns201WithBothFrequencies()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 36.525m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("primaryFrequency").GetDecimal().Should().Be(36.500m);
+        body.GetProperty("alternateFrequency").GetDecimal().Should().Be(36.525m);
+    }
+
+    [Fact]
+    public async Task CreateAssignment_AlternateEqualsPrimary_Returns422WithMessage()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 36.500m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("Alternate frequency cannot match primary frequency");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_InvalidAlternateFrequency_Returns422()
+    {
+        // 90.0 MHz is out of VHF range
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 90.0m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("out of range");
+    }
+
+    [Fact]
+    public async Task CreateAssignment_InvalidAlternateSpacing_Returns422()
+    {
+        // 36.012 does not align to 25 kHz spacing
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 36.500m, alternateFrequency = 36.012m });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("25 kHz");
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_AddAlternateFrequency_Returns200()
+    {
+        // Create without alternate
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 50.500m });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update to add alternate
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 50.500m, alternateFrequency = 50.525m });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        updated.GetProperty("primaryFrequency").GetDecimal().Should().Be(50.500m);
+        updated.GetProperty("alternateFrequency").GetDecimal().Should().Be(50.525m);
+    }
+
+    [Fact]
+    public async Task UpdateAssignment_RemoveAlternateFrequency_Returns200WithNullAlternate()
+    {
+        // Create with alternate
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments",
+            new { radioChannelId = _channelVhfId, squadId = _squadId, primaryFrequency = 55.500m, alternateFrequency = 55.525m });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var assignmentId = created.GetProperty("id").GetGuid();
+
+        // Update with null alternate (removes it)
+        var updateResponse = await _commanderClient.PutAsJsonAsync(
+            $"/api/events/{_eventId}/channel-assignments/{assignmentId}",
+            new { primaryFrequency = 55.500m, alternateFrequency = (decimal?)null });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        updated.GetProperty("primaryFrequency").GetDecimal().Should().Be(55.500m);
+        // alternateFrequency should be null
+        updated.GetProperty("alternateFrequency").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api.Tests/RadioChannels/RadioChannelTests.cs
+++ b/milsim-platform/src/MilsimPlanning.Api.Tests/RadioChannels/RadioChannelTests.cs
@@ -1,0 +1,351 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Services;
+using MilsimPlanning.Api.Tests.Fixtures;
+using Moq;
+using Xunit;
+
+namespace MilsimPlanning.Api.Tests.RadioChannels;
+
+/// <summary>
+/// Integration tests for radio channel CRUD API (Story 1).
+/// Covers AC-01 through AC-08: create, list, edit, duplicate name validation, VHF/UHF scope.
+/// </summary>
+public class RadioChannelTestsBase : IClassFixture<PostgreSqlFixture>, IAsyncLifetime
+{
+    protected readonly PostgreSqlFixture _fixture;
+    protected WebApplicationFactory<Program> _factory = null!;
+    protected Mock<IEmailService> _emailMock = null!;
+    protected HttpClient _commanderClient = null!;
+    protected HttpClient _playerClient = null!;
+    protected Guid _eventId;
+    protected Guid _factionId;
+    protected string _commanderUserId = string.Empty;
+    protected string _playerUserId = string.Empty;
+
+    public RadioChannelTestsBase(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _emailMock = new Mock<IEmailService>();
+        _emailMock.Setup(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(Task.CompletedTask);
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Jwt:Secret"] = "dev-placeholder-secret-32-chars!!",
+                        ["Jwt:Issuer"] = "milsim-tests",
+                        ["Jwt:Audience"] = "milsim-tests"
+                    });
+                });
+
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<DbContextOptions<AppDbContext>>();
+                    services.RemoveAll<AppDbContext>();
+                    services.AddDbContext<AppDbContext>(opts =>
+                        opts.UseNpgsql(_fixture.ConnectionString));
+
+                    services.RemoveAll<IEmailService>();
+                    services.AddSingleton(_emailMock.Object);
+
+                    services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = IntegrationTestAuthHandler.SchemeName;
+                        options.DefaultChallengeScheme = IntegrationTestAuthHandler.SchemeName;
+                    }).AddScheme<AuthenticationSchemeOptions, IntegrationTestAuthHandler>(IntegrationTestAuthHandler.SchemeName, _ => { });
+                });
+            });
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.MigrateAsync();
+
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        foreach (var role in new[] { "player", "squad_leader", "platoon_leader", "faction_commander", "system_admin" })
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+                await roleManager.CreateAsync(new IdentityRole(role));
+        }
+
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+
+        // Commander
+        var cmdEmail = $"rc-cmdr-{Guid.NewGuid():N}@test.com";
+        var commander = new AppUser { UserName = cmdEmail, Email = cmdEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(commander, "TestPass123!");
+        await userManager.AddToRoleAsync(commander, "faction_commander");
+        commander.Profile = new UserProfile { UserId = commander.Id, Callsign = "Commander", DisplayName = "Commander", User = commander };
+        _commanderUserId = commander.Id;
+
+        // Player
+        var playerEmail = $"rc-player-{Guid.NewGuid():N}@test.com";
+        var player = new AppUser { UserName = playerEmail, Email = playerEmail, EmailConfirmed = true };
+        await userManager.CreateAsync(player, "TestPass123!");
+        await userManager.AddToRoleAsync(player, "player");
+        player.Profile = new UserProfile { UserId = player.Id, Callsign = "Player1", DisplayName = "Player1", User = player };
+        _playerUserId = player.Id;
+
+        // Seed event
+        _eventId = Guid.NewGuid();
+        _factionId = Guid.NewGuid();
+
+        var faction = new Faction { Id = _factionId, Name = "Blue Force", CommanderId = commander.Id, EventId = _eventId };
+        var testEvent = new Event { Id = _eventId, Name = "RC Test Event", Status = EventStatus.Draft, FactionId = _factionId, Faction = faction };
+
+        db.Events.Add(testEvent);
+        await db.SaveChangesAsync();
+
+        db.EventMemberships.Add(new EventMembership { UserId = commander.Id, EventId = _eventId, Role = "faction_commander" });
+        db.EventMemberships.Add(new EventMembership { UserId = player.Id, EventId = _eventId, Role = "player" });
+        await db.SaveChangesAsync();
+
+        _commanderClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_commanderClient, commander.Id, "faction_commander");
+        _playerClient = _factory.CreateClient();
+        IntegrationTestAuthHandler.ApplyTestIdentity(_playerClient, player.Id, "player");
+    }
+
+    public Task DisposeAsync()
+    {
+        _commanderClient.Dispose();
+        _playerClient.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+}
+
+public class RadioChannelTests : RadioChannelTestsBase
+{
+    public RadioChannelTests(PostgreSqlFixture fixture) : base(fixture) { }
+
+    // ── Create ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateChannel_AsCommander_ReturnsCreatedChannel()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Command Net", scope = "VHF" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("name").GetString().Should().Be("Command Net");
+        body.GetProperty("scope").GetString().Should().Be("VHF");
+    }
+
+    [Fact]
+    public async Task CreateChannel_WithUHFScope_ReturnsUHFChannel()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Air Net", scope = "UHF" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("scope").GetString().Should().Be("UHF");
+    }
+
+    [Fact]
+    public async Task CreateChannel_WithInvalidScope_Returns400()
+    {
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Bad Scope Channel", scope = "INVALID" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateChannel_AsPlayer_Returns403()
+    {
+        var response = await _playerClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Unauthorized Channel", scope = "VHF" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task CreateChannel_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var response = await anonClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Anon Channel", scope = "VHF" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        anonClient.Dispose();
+    }
+
+    // ── AC-05: Duplicate name validation ──────────────────────────────────────
+
+    [Fact]
+    public async Task CreateChannel_DuplicateName_Returns409WithMessage()
+    {
+        // Create first
+        await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Dup Net", scope = "VHF" });
+
+        // Try duplicate
+        var response = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Dup Net", scope = "UHF" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("detail").GetString().Should().Contain("Channel name already exists");
+    }
+
+    // ── List ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListChannels_AsPlayer_ReturnsChannels()
+    {
+        // Create a channel first
+        await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "List Test Net", scope = "VHF" });
+
+        var response = await _playerClient.GetAsync($"/api/events/{_eventId}/radio-channels");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact]
+    public async Task ListChannels_IDOR_Returns403ForOtherEvent()
+    {
+        var otherEventId = Guid.NewGuid();
+        var response = await _commanderClient.GetAsync($"/api/events/{otherEventId}/radio-channels");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListChannels_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var response = await anonClient.GetAsync($"/api/events/{_eventId}/radio-channels");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        anonClient.Dispose();
+    }
+
+    // ── AC-07: Edit channel name ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateChannel_AsCommander_ReturnsUpdatedChannel()
+    {
+        // Create
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Edit Me Net", scope = "VHF" });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var channelId = created.GetProperty("id").GetGuid();
+
+        // Update
+        var updateResponse = await _commanderClient.PatchAsJsonAsync(
+            $"/api/radio-channels/{channelId}",
+            new { name = "Renamed Net", scope = "UHF" });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("name").GetString().Should().Be("Renamed Net");
+        body.GetProperty("scope").GetString().Should().Be("UHF");
+    }
+
+    [Fact]
+    public async Task UpdateChannel_DuplicateName_Returns409()
+    {
+        // Create two channels
+        await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "First Net", scope = "VHF" });
+
+        var secondResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Second Net", scope = "VHF" });
+
+        var second = await secondResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var secondId = second.GetProperty("id").GetGuid();
+
+        // Try to rename second to first's name
+        var updateResponse = await _commanderClient.PatchAsJsonAsync(
+            $"/api/radio-channels/{secondId}",
+            new { name = "First Net", scope = "VHF" });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task UpdateChannel_AsPlayer_Returns403()
+    {
+        // Create channel as commander
+        var createResponse = await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = "Player Edit Test", scope = "VHF" });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var channelId = created.GetProperty("id").GetGuid();
+
+        // Player tries to update
+        var updateResponse = await _playerClient.PatchAsJsonAsync(
+            $"/api/radio-channels/{channelId}",
+            new { name = "Hacked Name", scope = "VHF" });
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task UpdateChannel_NonExistent_Returns404()
+    {
+        var fakeId = Guid.NewGuid();
+        var response = await _commanderClient.PatchAsJsonAsync(
+            $"/api/radio-channels/{fakeId}",
+            new { name = "Ghost Channel", scope = "VHF" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── AC-06 + AC-08: Channel list shows name and scope ──────────────────────
+
+    [Fact]
+    public async Task CreateChannel_ThenList_AppearsWithNameAndScope()
+    {
+        var uniqueName = $"List Verify {Guid.NewGuid():N}";
+
+        await _commanderClient.PostAsJsonAsync(
+            $"/api/events/{_eventId}/radio-channels",
+            new { name = uniqueName, scope = "UHF" });
+
+        var listResponse = await _commanderClient.GetAsync($"/api/events/{_eventId}/radio-channels");
+        var channels = await listResponse.Content.ReadFromJsonAsync<JsonElement>();
+
+        var found = channels.EnumerateArray()
+            .FirstOrDefault(c => c.GetProperty("name").GetString() == uniqueName);
+
+        found.ValueKind.Should().Be(JsonValueKind.Object);
+        found.GetProperty("scope").GetString().Should().Be("UHF");
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Authorization/Exceptions/FrequencyConflictException.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Authorization/Exceptions/FrequencyConflictException.cs
@@ -1,0 +1,20 @@
+namespace MilsimPlanning.Api.Authorization;
+
+/// <summary>
+/// Thrown when a frequency assignment conflicts with an existing assignment on the same channel.
+/// Maps to HTTP 409 Conflict.
+/// </summary>
+public class FrequencyConflictException : Exception
+{
+    public string ConflictingSquadName { get; }
+    public decimal ConflictingFrequency { get; }
+    public string ConflictType { get; } // "primary" | "alternate"
+
+    public FrequencyConflictException(string conflictingSquadName, decimal conflictingFrequency, string conflictType)
+        : base($"Frequency {conflictingFrequency:F3} MHz conflicts with {conflictType} frequency assigned to '{conflictingSquadName}'.")
+    {
+        ConflictingSquadName = conflictingSquadName;
+        ConflictingFrequency = conflictingFrequency;
+        ConflictType = conflictType;
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
@@ -45,6 +45,7 @@ public class ChannelAssignmentsController : ControllerBase
             var result = await _service.CreateAssignmentAsync(eventId, request);
             return StatusCode(201, result);
         }
+        catch (FrequencyConflictException ex) { return Problem(title: "Frequency Conflict", detail: ex.Message, statusCode: 409); }
         catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
         catch (ArgumentException ex) { return Problem(title: "Validation Error", detail: ex.Message, statusCode: 422); }
         catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
@@ -64,6 +65,7 @@ public class ChannelAssignmentsController : ControllerBase
             var result = await _service.UpdateAssignmentAsync(eventId, id, request);
             return Ok(result);
         }
+        catch (FrequencyConflictException ex) { return Problem(title: "Frequency Conflict", detail: ex.Message, statusCode: 409); }
         catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
         catch (ArgumentException ex) { return Problem(title: "Validation Error", detail: ex.Message, statusCode: 422); }
         catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Models.ChannelAssignments;
+using MilsimPlanning.Api.Services;
+
+namespace MilsimPlanning.Api.Controllers;
+
+[ApiController]
+public class ChannelAssignmentsController : ControllerBase
+{
+    private readonly ChannelAssignmentService _service;
+
+    public ChannelAssignmentsController(ChannelAssignmentService service)
+        => _service = service;
+
+    // ── GET /api/events/{eventId}/channel-assignments ─────────────────────────
+
+    [HttpGet("api/events/{eventId:guid}/channel-assignments")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<ChannelAssignmentListDto>> GetAssignments(
+        Guid eventId,
+        [FromQuery] int limit = 50,
+        [FromQuery] int offset = 0)
+    {
+        try
+        {
+            var result = await _service.GetAssignmentsAsync(eventId, limit, offset);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── POST /api/events/{eventId}/channel-assignments ────────────────────────
+
+    [HttpPost("api/events/{eventId:guid}/channel-assignments")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<ChannelAssignmentDto>> CreateAssignment(
+        Guid eventId,
+        [FromBody] CreateChannelAssignmentRequest request)
+    {
+        try
+        {
+            var result = await _service.CreateAssignmentAsync(eventId, request);
+            return StatusCode(201, result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ArgumentException ex) { return Problem(title: "Validation Error", detail: ex.Message, statusCode: 422); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── PUT /api/events/{eventId}/channel-assignments/{id} ───────────────────
+
+    [HttpPut("api/events/{eventId:guid}/channel-assignments/{id:guid}")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<ChannelAssignmentDto>> UpdateAssignment(
+        Guid eventId,
+        Guid id,
+        [FromBody] UpdateChannelAssignmentRequest request)
+    {
+        try
+        {
+            var result = await _service.UpdateAssignmentAsync(eventId, id, request);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ArgumentException ex) { return Problem(title: "Validation Error", detail: ex.Message, statusCode: 422); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── DELETE /api/events/{eventId}/channel-assignments/{id} ────────────────
+
+    [HttpDelete("api/events/{eventId:guid}/channel-assignments/{id:guid}")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<IActionResult> DeleteAssignment(Guid eventId, Guid id)
+    {
+        try
+        {
+            await _service.DeleteAssignmentAsync(eventId, id);
+            return NoContent();
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/ChannelAssignmentsController.cs
@@ -85,4 +85,20 @@ public class ChannelAssignmentsController : ControllerBase
         catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
         catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
     }
+
+    // ── GET /api/events/{eventId}/channel-assignments/conflicts ───────────────
+    // AC-07: Planner can view conflict summary: which units share frequency, affected channels
+
+    [HttpGet("api/events/{eventId:guid}/channel-assignments/conflicts")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<ChannelAssignmentConflictSummaryDto>> GetConflicts(Guid eventId)
+    {
+        try
+        {
+            var result = await _service.GetConflictsAsync(eventId);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Controllers/RadioChannelsController.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Controllers/RadioChannelsController.cs
@@ -1,0 +1,160 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Models.Channels;
+using MilsimPlanning.Api.Services;
+
+namespace MilsimPlanning.Api.Controllers;
+
+[ApiController]
+public class RadioChannelsController : ControllerBase
+{
+    private readonly RadioChannelAssignmentService _assignmentService;
+    private readonly RadioChannelConflictSummaryService _conflictSummaryService;
+    private readonly RadioChannelChannelService _channelService;
+
+    public RadioChannelsController(
+        RadioChannelAssignmentService assignmentService,
+        RadioChannelConflictSummaryService conflictSummaryService,
+        RadioChannelChannelService channelService)
+    {
+        _assignmentService = assignmentService;
+        _conflictSummaryService = conflictSummaryService;
+        _channelService = channelService;
+    }
+
+    // ── GET /api/events/{eventId}/radio-channels ──────────────────────────────
+
+    [HttpGet("api/events/{eventId:guid}/radio-channels")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<List<RadioChannelListDto>>> GetEventChannels(Guid eventId)
+    {
+        try
+        {
+            var result = await _channelService.ListAsync(eventId);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── POST /api/events/{eventId}/radio-channels ─────────────────────────────
+
+    [HttpPost("api/events/{eventId:guid}/radio-channels")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<RadioChannelDetailDto>> CreateChannel(
+        Guid eventId,
+        [FromBody] CreateRadioChannelRequest request)
+    {
+        try
+        {
+            var result = await _channelService.CreateAsync(eventId, request);
+            return CreatedAtAction(
+                nameof(GetEventChannels),
+                new { eventId },
+                result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (InvalidOperationException ex) { return Problem(title: "Conflict", detail: ex.Message, statusCode: 409); }
+        catch (ArgumentException ex) { return Problem(title: "Bad Request", detail: ex.Message, statusCode: 400); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── PATCH /api/radio-channels/{channelId} ────────────────────────────────
+    // AC-07: Planner can edit channel name post-creation
+
+    [HttpPatch("api/radio-channels/{channelId:guid}")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<RadioChannelDetailDto>> UpdateChannel(
+        Guid channelId,
+        [FromBody] UpdateRadioChannelRequest request)
+    {
+        try
+        {
+            var result = await _channelService.UpdateAsync(channelId, request);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (InvalidOperationException ex) { return Problem(title: "Conflict", detail: ex.Message, statusCode: 409); }
+        catch (ArgumentException ex) { return Problem(title: "Bad Request", detail: ex.Message, statusCode: 400); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── GET /api/radio-channels/{channelId}/assignments ───────────────────────
+
+    [HttpGet("api/radio-channels/{channelId:guid}/assignments")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<List<RadioChannelAssignmentDto>>> GetAssignments(Guid channelId)
+    {
+        try
+        {
+            var result = await _assignmentService.GetAssignmentsAsync(channelId);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── PUT /api/radio-channels/{channelId}/assignments/{unitType}/{unitId} ───
+    // AC-04: returns 409 with conflict details when overrideValidation=false and conflicts exist
+
+    [HttpPut("api/radio-channels/{channelId:guid}/assignments/{unitType}/{unitId:guid}")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<ActionResult<RadioChannelAssignmentDto>> UpsertAssignment(
+        Guid channelId,
+        string unitType,
+        Guid unitId,
+        [FromBody] AssignFrequencyRequest request)
+    {
+        try
+        {
+            var result = await _assignmentService.UpsertAssignmentAsync(channelId, unitType, unitId, request);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (InvalidOperationException ex)
+        {
+            // AC-04: 409 with conflict detail in extensions
+            return Problem(
+                title: "Frequency Conflict",
+                detail: ex.Message,
+                statusCode: 409);
+        }
+        catch (ArgumentException ex) { return Problem(title: "Bad Request", detail: ex.Message, statusCode: 400); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── DELETE /api/radio-channels/{channelId}/assignments/{unitType}/{unitId} ─
+
+    [HttpDelete("api/radio-channels/{channelId:guid}/assignments/{unitType}/{unitId:guid}")]
+    [Authorize(Policy = "RequireFactionCommander")]
+    public async Task<IActionResult> DeleteAssignment(
+        Guid channelId,
+        string unitType,
+        Guid unitId)
+    {
+        try
+        {
+            await _assignmentService.DeleteAssignmentAsync(channelId, unitType, unitId);
+            return NoContent();
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+
+    // ── GET /api/events/{eventId}/radio-channels/conflicts ───────────────────
+    // AC-07: planner can view conflict summary
+
+    [HttpGet("api/events/{eventId:guid}/radio-channels/conflicts")]
+    [Authorize(Policy = "RequirePlayer")]
+    public async Task<ActionResult<ConflictSummaryDto>> GetConflictSummary(Guid eventId)
+    {
+        try
+        {
+            var result = await _conflictSummaryService.GetConflictSummaryAsync(eventId);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex) { return Problem(title: "Not Found", detail: ex.Message, statusCode: 404); }
+        catch (ForbiddenException ex) { return Problem(title: "Forbidden", detail: ex.Message, statusCode: 403); }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
@@ -212,6 +212,10 @@ public class AppDbContext : IdentityDbContext<AppUser>
             .Property(a => a.PrimaryFrequency)
             .HasColumnType("decimal(8,3)");
 
+        builder.Entity<ChannelAssignment>()
+            .Property(a => a.AlternateFrequency)
+            .HasColumnType("decimal(8,3)");
+
         // Soft-delete global filter — excludes IsDeleted rows from all queries
         builder.Entity<ChannelAssignment>()
             .HasQueryFilter(a => !a.IsDeleted);

--- a/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
@@ -212,6 +212,10 @@ public class AppDbContext : IdentityDbContext<AppUser>
             .Property(a => a.PrimaryFrequency)
             .HasColumnType("decimal(8,3)");
 
+        // Soft-delete global filter — excludes IsDeleted rows from all queries
+        builder.Entity<ChannelAssignment>()
+            .HasQueryFilter(a => !a.IsDeleted);
+
         // FrequencyConflict → Event
         builder.Entity<FrequencyConflict>()
             .HasOne(fc => fc.Event)

--- a/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/AppDbContext.cs
@@ -28,6 +28,13 @@ public class AppDbContext : IdentityDbContext<AppUser>
     // Phase 4 DbSets
     public DbSet<RosterChangeRequest> RosterChangeRequests => Set<RosterChangeRequest>();
 
+    // Phase 5/6 DbSets — Radio Channels
+    public DbSet<RadioChannel> RadioChannels => Set<RadioChannel>();
+    public DbSet<RadioChannelAssignment> RadioChannelAssignments => Set<RadioChannelAssignment>();
+    public DbSet<ChannelAssignment> ChannelAssignments => Set<ChannelAssignment>();
+    public DbSet<FrequencyConflict> FrequencyConflicts => Set<FrequencyConflict>();
+    public DbSet<FrequencyAuditLog> FrequencyAuditLogs => Set<FrequencyAuditLog>();
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder); // MUST be first — sets up Identity tables
@@ -131,5 +138,98 @@ public class AppDbContext : IdentityDbContext<AppUser>
         // RosterChangeRequest indexes: fast lookup for "all pending for event"
         builder.Entity<RosterChangeRequest>()
             .HasIndex(r => new { r.EventId, r.Status });
+
+        // === Phase 5/6 Configuration — Radio Channels ===
+
+        // RadioChannel → Event
+        builder.Entity<RadioChannel>()
+            .HasOne(rc => rc.Event)
+            .WithMany()
+            .HasForeignKey(rc => rc.EventId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // RadioChannel ordering per event
+        builder.Entity<RadioChannel>()
+            .HasIndex(rc => new { rc.EventId, rc.Order });
+
+        // RadioChannelAssignment → RadioChannel (cascade delete)
+        builder.Entity<RadioChannelAssignment>()
+            .HasOne(a => a.Channel)
+            .WithMany(rc => rc.Assignments)
+            .HasForeignKey(a => a.ChannelId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // RadioChannelAssignment optional FK → Squad
+        builder.Entity<RadioChannelAssignment>()
+            .HasOne(a => a.Squad)
+            .WithMany()
+            .HasForeignKey(a => a.SquadId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        // RadioChannelAssignment optional FK → Platoon
+        builder.Entity<RadioChannelAssignment>()
+            .HasOne(a => a.Platoon)
+            .WithMany()
+            .HasForeignKey(a => a.PlatoonId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        // RadioChannelAssignment optional FK → Faction
+        builder.Entity<RadioChannelAssignment>()
+            .HasOne(a => a.Faction)
+            .WithMany()
+            .HasForeignKey(a => a.FactionId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        // RadioChannelAssignment decimal precision
+        builder.Entity<RadioChannelAssignment>()
+            .Property(a => a.Primary)
+            .HasColumnType("decimal(7,3)");
+
+        builder.Entity<RadioChannelAssignment>()
+            .Property(a => a.Alternate)
+            .HasColumnType("decimal(7,3)");
+
+        // ChannelAssignment (legacy) relationships
+        builder.Entity<ChannelAssignment>()
+            .HasOne(a => a.RadioChannel)
+            .WithMany()
+            .HasForeignKey(a => a.RadioChannelId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<ChannelAssignment>()
+            .HasOne(a => a.Squad)
+            .WithMany()
+            .HasForeignKey(a => a.SquadId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<ChannelAssignment>()
+            .HasOne(a => a.Event)
+            .WithMany()
+            .HasForeignKey(a => a.EventId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<ChannelAssignment>()
+            .Property(a => a.PrimaryFrequency)
+            .HasColumnType("decimal(8,3)");
+
+        // FrequencyConflict → Event
+        builder.Entity<FrequencyConflict>()
+            .HasOne(fc => fc.Event)
+            .WithMany()
+            .HasForeignKey(fc => fc.EventId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<FrequencyConflict>()
+            .HasIndex(fc => new { fc.EventId, fc.Status });
+
+        // FrequencyAuditLog → Event
+        builder.Entity<FrequencyAuditLog>()
+            .HasOne(al => al.Event)
+            .WithMany()
+            .HasForeignKey(al => al.EventId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<FrequencyAuditLog>()
+            .HasIndex(al => new { al.EventId, al.OccurredAt });
     }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
@@ -12,6 +12,7 @@ public class ChannelAssignment
     public Guid SquadId { get; set; }
     public Guid EventId { get; set; }
     public decimal PrimaryFrequency { get; set; }
+    public decimal? AlternateFrequency { get; set; }
     public bool IsDeleted { get; set; } = false;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
@@ -13,6 +13,7 @@ public class ChannelAssignment
     public Guid EventId { get; set; }
     public decimal PrimaryFrequency { get; set; }
     public decimal? AlternateFrequency { get; set; }
+    public bool HasConflict { get; set; } = false;   // AC-05: conflict state persisted on record
     public bool IsDeleted { get; set; } = false;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/ChannelAssignment.cs
@@ -1,0 +1,23 @@
+namespace MilsimPlanning.Api.Data.Entities;
+
+/// <summary>
+/// Legacy squad-only channel assignment entity.
+/// Supports basic frequency assignment per squad per radio channel.
+/// Use RadioChannelAssignment for the polymorphic (squad/platoon/faction) model with conflict detection.
+/// </summary>
+public class ChannelAssignment
+{
+    public Guid Id { get; set; }
+    public Guid RadioChannelId { get; set; }
+    public Guid SquadId { get; set; }
+    public Guid EventId { get; set; }
+    public decimal PrimaryFrequency { get; set; }
+    public bool IsDeleted { get; set; } = false;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation
+    public RadioChannel RadioChannel { get; set; } = null!;
+    public Squad Squad { get; set; } = null!;
+    public Event Event { get; set; } = null!;
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/FrequencyAuditLog.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/FrequencyAuditLog.cs
@@ -1,0 +1,29 @@
+namespace MilsimPlanning.Api.Data.Entities;
+
+/// <summary>
+/// Audit log entry for frequency assignment changes.
+/// Written by the assignment service on create/update/delete (Story 6+).
+/// </summary>
+public class FrequencyAuditLog
+{
+    public Guid Id { get; set; }
+    public Guid EventId { get; set; }
+
+    public string UnitType { get; set; } = null!;
+    public Guid UnitId { get; set; }
+    public string UnitName { get; set; } = null!;
+
+    public string? PrimaryFrequency { get; set; }
+    public string? AlternateFrequency { get; set; }
+
+    public string ActionType { get; set; } = null!;
+    public string? ConflictingUnitName { get; set; }
+
+    public string PerformedByUserId { get; set; } = null!;
+    public string PerformedByDisplayName { get; set; } = null!;
+
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation
+    public Event Event { get; set; } = null!;
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/FrequencyConflict.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/FrequencyConflict.cs
@@ -1,0 +1,30 @@
+namespace MilsimPlanning.Api.Data.Entities;
+
+/// <summary>
+/// Represents a detected frequency conflict between two units.
+/// Populated by the conflict-detection service (Story 4+).
+/// </summary>
+public class FrequencyConflict
+{
+    public Guid Id { get; set; }
+    public Guid EventId { get; set; }
+    public string Frequency { get; set; } = null!;
+    public string FrequencyType { get; set; } = null!;
+
+    // Unit A
+    public string UnitAType { get; set; } = null!;
+    public Guid UnitAId { get; set; }
+    public string UnitAName { get; set; } = null!;
+
+    // Unit B
+    public string UnitBType { get; set; } = null!;
+    public Guid UnitBId { get; set; }
+    public string UnitBName { get; set; } = null!;
+
+    public string Status { get; set; } = "Active";
+    public string ActionTaken { get; set; } = null!;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation
+    public Event Event { get; set; } = null!;
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/RadioChannel.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/RadioChannel.cs
@@ -1,0 +1,21 @@
+namespace MilsimPlanning.Api.Data.Entities;
+
+public enum ChannelScope
+{
+    VHF = 0,
+    UHF = 1
+}
+
+public class RadioChannel
+{
+    public Guid Id { get; set; }
+    public Guid EventId { get; set; }
+    public string Name { get; set; } = null!;
+    public string? CallSign { get; set; }
+    public ChannelScope Scope { get; set; } = ChannelScope.VHF;
+    public int Order { get; set; }
+    public bool IsDeleted { get; set; } = false;
+
+    public Event Event { get; set; } = null!;
+    public ICollection<RadioChannelAssignment> Assignments { get; set; } = [];
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Entities/RadioChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Entities/RadioChannelAssignment.cs
@@ -1,0 +1,25 @@
+namespace MilsimPlanning.Api.Data.Entities;
+
+public class RadioChannelAssignment
+{
+    public Guid Id { get; set; }
+    public Guid ChannelId { get; set; }
+
+    // Polymorphic unit reference — exactly one of these is non-null
+    public Guid? SquadId { get; set; }
+    public Guid? PlatoonId { get; set; }
+    public Guid? FactionId { get; set; }
+
+    public decimal? Primary { get; set; }   // MHz, decimal(7,3)
+    public decimal? Alternate { get; set; } // MHz, decimal(7,3)
+    public bool HasConflict { get; set; } = false;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; set; }
+
+    // Navigation
+    public RadioChannel Channel { get; set; } = null!;
+    public Squad? Squad { get; set; }
+    public Platoon? Platoon { get; set; }
+    public Faction? Faction { get; set; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425000001_Phase6RadioChannelAssignments.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425000001_Phase6RadioChannelAssignments.cs
@@ -1,0 +1,168 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MilsimPlanning.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Phase6RadioChannelAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // RadioChannels table
+            migrationBuilder.CreateTable(
+                name: "RadioChannels",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Scope = table.Column<int>(type: "integer", nullable: false),
+                    Order = table.Column<int>(type: "integer", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RadioChannels", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RadioChannels_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RadioChannels_EventId",
+                table: "RadioChannels",
+                column: "EventId");
+
+            // ChannelAssignments table
+            migrationBuilder.CreateTable(
+                name: "ChannelAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    RadioChannelId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SquadId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PrimaryFrequency = table.Column<decimal>(type: "decimal(8,3)", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChannelAssignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChannelAssignments_RadioChannels_RadioChannelId",
+                        column: x => x.RadioChannelId,
+                        principalTable: "RadioChannels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChannelAssignments_Squads_SquadId",
+                        column: x => x.SquadId,
+                        principalTable: "Squads",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ChannelAssignments_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelAssignments_EventId",
+                table: "ChannelAssignments",
+                column: "EventId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChannelAssignments_SquadId_RadioChannelId",
+                table: "ChannelAssignments",
+                columns: new[] { "SquadId", "RadioChannelId" });
+
+            // FrequencyAuditLogs table
+            migrationBuilder.CreateTable(
+                name: "FrequencyAuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UnitType = table.Column<string>(type: "text", nullable: false),
+                    UnitId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UnitName = table.Column<string>(type: "text", nullable: false),
+                    PrimaryFrequency = table.Column<string>(type: "text", nullable: true),
+                    AlternateFrequency = table.Column<string>(type: "text", nullable: true),
+                    ActionType = table.Column<string>(type: "text", nullable: false),
+                    ConflictingUnitName = table.Column<string>(type: "text", nullable: true),
+                    PerformedByUserId = table.Column<string>(type: "text", nullable: false),
+                    PerformedByDisplayName = table.Column<string>(type: "text", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FrequencyAuditLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FrequencyAuditLogs_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FrequencyAuditLogs_EventId_OccurredAt",
+                table: "FrequencyAuditLogs",
+                columns: new[] { "EventId", "OccurredAt" });
+
+            // FrequencyConflicts table
+            migrationBuilder.CreateTable(
+                name: "FrequencyConflicts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    EventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Frequency = table.Column<string>(type: "text", nullable: false),
+                    FrequencyType = table.Column<string>(type: "text", nullable: false),
+                    UnitAType = table.Column<string>(type: "text", nullable: false),
+                    UnitAId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UnitAName = table.Column<string>(type: "text", nullable: false),
+                    UnitBType = table.Column<string>(type: "text", nullable: false),
+                    UnitBId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UnitBName = table.Column<string>(type: "text", nullable: false),
+                    Status = table.Column<string>(type: "text", nullable: false, defaultValue: "Active"),
+                    ActionTaken = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FrequencyConflicts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FrequencyConflicts_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FrequencyConflicts_EventId_Status",
+                table: "FrequencyConflicts",
+                columns: new[] { "EventId", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "ChannelAssignments");
+            migrationBuilder.DropTable(name: "FrequencyAuditLogs");
+            migrationBuilder.DropTable(name: "FrequencyConflicts");
+            migrationBuilder.DropTable(name: "RadioChannels");
+        }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425100000_AddRadioChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425100000_AddRadioChannelAssignment.cs
@@ -1,0 +1,92 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MilsimPlanning.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRadioChannelAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Add CallSign to RadioChannels (Story 4 requirement)
+            migrationBuilder.AddColumn<string>(
+                name: "CallSign",
+                table: "RadioChannels",
+                type: "text",
+                nullable: true);
+
+            // RadioChannelAssignments table — polymorphic unit reference
+            migrationBuilder.CreateTable(
+                name: "RadioChannelAssignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ChannelId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SquadId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PlatoonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    FactionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Primary = table.Column<decimal>(type: "decimal(7,3)", nullable: true),
+                    Alternate = table.Column<decimal>(type: "decimal(7,3)", nullable: true),
+                    HasConflict = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RadioChannelAssignments", x => x.Id);
+
+                    table.ForeignKey(
+                        name: "FK_RadioChannelAssignments_RadioChannels_ChannelId",
+                        column: x => x.ChannelId,
+                        principalTable: "RadioChannels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+
+                    table.ForeignKey(
+                        name: "FK_RadioChannelAssignments_Squads_SquadId",
+                        column: x => x.SquadId,
+                        principalTable: "Squads",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+
+                    table.ForeignKey(
+                        name: "FK_RadioChannelAssignments_Platoons_PlatoonId",
+                        column: x => x.PlatoonId,
+                        principalTable: "Platoons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+
+                    table.ForeignKey(
+                        name: "FK_RadioChannelAssignments_AspNetUsers_FactionId",
+                        column: x => x.FactionId,
+                        principalTable: "Factions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            // Indexes for conflict detection lookups
+            migrationBuilder.CreateIndex(
+                name: "IX_RadioChannelAssignments_ChannelId_Primary",
+                table: "RadioChannelAssignments",
+                columns: new[] { "ChannelId", "Primary" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RadioChannelAssignments_ChannelId_Alternate",
+                table: "RadioChannelAssignments",
+                columns: new[] { "ChannelId", "Alternate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "RadioChannelAssignments");
+
+            migrationBuilder.DropColumn(
+                name: "CallSign",
+                table: "RadioChannels");
+        }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425223949_AddAlternateFrequencyToChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260425223949_AddAlternateFrequencyToChannelAssignment.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MilsimPlanning.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAlternateFrequencyToChannelAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Story 3 — add optional alternate frequency to squad channel assignments
+            migrationBuilder.AddColumn<decimal>(
+                name: "AlternateFrequency",
+                table: "ChannelAssignments",
+                type: "numeric(8,3)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AlternateFrequency",
+                table: "ChannelAssignments");
+        }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260426000001_AddHasConflictToChannelAssignment.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/20260426000001_AddHasConflictToChannelAssignment.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MilsimPlanning.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHasConflictToChannelAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Story 4 — AC-05: persist conflict state on assignment record
+            migrationBuilder.AddColumn<bool>(
+                name: "HasConflict",
+                table: "ChannelAssignments",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HasConflict",
+                table: "ChannelAssignments");
+        }
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/AppDbContextModelSnapshot.cs
@@ -233,6 +233,11 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.Property<Guid>("EventId")
                         .HasColumnType("uuid");
 
+                    b.Property<bool>("HasConflict")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValue(false);
+
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("boolean");
 

--- a/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Data/Migrations/AppDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace MilsimPlanning.Api.Data.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.5")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -218,6 +218,47 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.ChannelAssignment", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal?>("AlternateFrequency")
+                        .HasColumnType("decimal(8,3)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<decimal>("PrimaryFrequency")
+                        .HasColumnType("decimal(8,3)");
+
+                    b.Property<Guid>("RadioChannelId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("SquadId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("RadioChannelId");
+
+                    b.HasIndex("SquadId");
+
+                    b.ToTable("ChannelAssignments");
+                });
+
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.Event", b =>
                 {
                     b.Property<Guid>("Id")
@@ -364,6 +405,114 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsUnique();
 
                     b.ToTable("Factions");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyAuditLog", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("ActionType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("AlternateFrequency")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ConflictingUnitName")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("OccurredAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("PerformedByDisplayName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("PerformedByUserId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("PrimaryFrequency")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UnitId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UnitName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UnitType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId", "OccurredAt");
+
+                    b.ToTable("FrequencyAuditLogs");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyConflict", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("ActionTaken")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Frequency")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("FrequencyType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UnitAId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UnitAName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UnitAType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UnitBId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UnitBName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("UnitBType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId", "Status");
+
+                    b.ToTable("FrequencyConflicts");
                 });
 
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.InfoSection", b =>
@@ -546,6 +695,84 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.ToTable("Platoons");
                 });
 
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannel", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("CallSign")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("EventId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<int>("Order")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Scope")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId", "Order");
+
+                    b.ToTable("RadioChannels");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannelAssignment", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal?>("Alternate")
+                        .HasColumnType("decimal(7,3)");
+
+                    b.Property<Guid>("ChannelId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("FactionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("HasConflict")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid?>("PlatoonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal?>("Primary")
+                        .HasColumnType("decimal(7,3)");
+
+                    b.Property<Guid?>("SquadId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ChannelId");
+
+                    b.HasIndex("FactionId");
+
+                    b.HasIndex("PlatoonId");
+
+                    b.HasIndex("SquadId");
+
+                    b.ToTable("RadioChannelAssignments");
+                });
+
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RosterChangeRequest", b =>
                 {
                     b.Property<Guid>("Id")
@@ -689,6 +916,33 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsRequired();
                 });
 
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.ChannelAssignment", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.RadioChannel", "RadioChannel")
+                        .WithMany()
+                        .HasForeignKey("RadioChannelId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Squad", "Squad")
+                        .WithMany()
+                        .HasForeignKey("SquadId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+
+                    b.Navigation("RadioChannel");
+
+                    b.Navigation("Squad");
+                });
+
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.EventMembership", b =>
                 {
                     b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
@@ -752,6 +1006,28 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsRequired();
 
                     b.Navigation("Commander");
+
+                    b.Navigation("Event");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyAuditLog", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.FrequencyConflict", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.Navigation("Event");
                 });
@@ -820,6 +1096,49 @@ namespace MilsimPlanning.Api.Data.Migrations
                         .IsRequired();
 
                     b.Navigation("Faction");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannel", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Event", "Event")
+                        .WithMany()
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Event");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannelAssignment", b =>
+                {
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.RadioChannel", "Channel")
+                        .WithMany("Assignments")
+                        .HasForeignKey("ChannelId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Faction", "Faction")
+                        .WithMany()
+                        .HasForeignKey("FactionId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Platoon", "Platoon")
+                        .WithMany()
+                        .HasForeignKey("PlatoonId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne("MilsimPlanning.Api.Data.Entities.Squad", "Squad")
+                        .WithMany()
+                        .HasForeignKey("SquadId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.Navigation("Channel");
+
+                    b.Navigation("Faction");
+
+                    b.Navigation("Platoon");
+
+                    b.Navigation("Squad");
                 });
 
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RosterChangeRequest", b =>
@@ -900,6 +1219,11 @@ namespace MilsimPlanning.Api.Data.Migrations
                     b.Navigation("Players");
 
                     b.Navigation("Squads");
+                });
+
+            modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.RadioChannel", b =>
+                {
+                    b.Navigation("Assignments");
                 });
 
             modelBuilder.Entity("MilsimPlanning.Api.Data.Entities.Squad", b =>

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentConflictSummaryDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentConflictSummaryDto.cs
@@ -1,0 +1,21 @@
+namespace MilsimPlanning.Api.Models.ChannelAssignments;
+
+/// <summary>
+/// AC-07: Summary of all active frequency conflicts within an operation's channel assignments.
+/// </summary>
+public record ChannelAssignmentConflictSummaryDto
+{
+    public Guid EventId { get; init; }
+    public int ConflictCount { get; init; }
+    public List<ChannelAssignmentConflictItemDto> Conflicts { get; init; } = [];
+}
+
+public record ChannelAssignmentConflictItemDto
+{
+    public Guid AssignmentId { get; init; }
+    public string SquadName { get; init; } = null!;
+    public string ChannelName { get; init; } = null!;
+    public decimal ConflictingFrequency { get; init; }
+    public string FrequencyType { get; init; } = null!;  // "primary" | "alternate"
+    public string ConflictingSquadName { get; init; } = null!;
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
@@ -11,6 +11,8 @@ public record ChannelAssignmentDto
     public decimal PrimaryFrequency { get; init; }
     public decimal? AlternateFrequency { get; init; }
     public Guid EventId { get; init; }
+    public bool HasConflict { get; init; }           // AC-05: conflict state
+    public List<string>? ConflictWith { get; init; } // AC-07: names of conflicting units
     public DateTime CreatedAt { get; init; }
     public DateTime UpdatedAt { get; init; }
 }

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
@@ -9,6 +9,7 @@ public record ChannelAssignmentDto
     public Guid SquadId { get; init; }
     public string SquadName { get; init; } = null!;
     public decimal PrimaryFrequency { get; init; }
+    public decimal? AlternateFrequency { get; init; }
     public Guid EventId { get; init; }
     public DateTime CreatedAt { get; init; }
     public DateTime UpdatedAt { get; init; }

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentDto.cs
@@ -1,0 +1,15 @@
+namespace MilsimPlanning.Api.Models.ChannelAssignments;
+
+public record ChannelAssignmentDto
+{
+    public Guid Id { get; init; }
+    public Guid RadioChannelId { get; init; }
+    public string ChannelName { get; init; } = null!;
+    public string ChannelScope { get; init; } = null!;
+    public Guid SquadId { get; init; }
+    public string SquadName { get; init; } = null!;
+    public decimal PrimaryFrequency { get; init; }
+    public Guid EventId { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; init; }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentListDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/ChannelAssignmentListDto.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.ChannelAssignments;
+
+public record ChannelAssignmentListDto
+{
+    public int Total { get; init; }
+    public List<ChannelAssignmentDto> Items { get; init; } = [];
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
@@ -4,5 +4,6 @@ public record CreateChannelAssignmentRequest(
     Guid RadioChannelId,
     Guid SquadId,
     decimal PrimaryFrequency,
-    decimal? AlternateFrequency = null
+    decimal? AlternateFrequency = null,
+    bool OverrideConflict = false   // AC-04: advisory mode override flag
 );

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.ChannelAssignments;
+
+public record CreateChannelAssignmentRequest(
+    Guid RadioChannelId,
+    Guid SquadId,
+    decimal PrimaryFrequency
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/CreateChannelAssignmentRequest.cs
@@ -3,5 +3,6 @@ namespace MilsimPlanning.Api.Models.ChannelAssignments;
 public record CreateChannelAssignmentRequest(
     Guid RadioChannelId,
     Guid SquadId,
-    decimal PrimaryFrequency
+    decimal PrimaryFrequency,
+    decimal? AlternateFrequency = null
 );

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
@@ -1,5 +1,6 @@
 namespace MilsimPlanning.Api.Models.ChannelAssignments;
 
 public record UpdateChannelAssignmentRequest(
-    decimal PrimaryFrequency
+    decimal PrimaryFrequency,
+    decimal? AlternateFrequency = null
 );

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
@@ -2,5 +2,6 @@ namespace MilsimPlanning.Api.Models.ChannelAssignments;
 
 public record UpdateChannelAssignmentRequest(
     decimal PrimaryFrequency,
-    decimal? AlternateFrequency = null
+    decimal? AlternateFrequency = null,
+    bool OverrideConflict = false   // AC-04: advisory mode override flag
 );

--- a/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/ChannelAssignments/UpdateChannelAssignmentRequest.cs
@@ -1,0 +1,5 @@
+namespace MilsimPlanning.Api.Models.ChannelAssignments;
+
+public record UpdateChannelAssignmentRequest(
+    decimal PrimaryFrequency
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/AssignFrequencyRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/AssignFrequencyRequest.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record AssignFrequencyRequest(
+    decimal? Primary,
+    decimal? Alternate,
+    bool OverrideValidation = false
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/ConflictItemDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/ConflictItemDto.cs
@@ -1,0 +1,11 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record ConflictItemDto(
+    Guid AssignmentId,
+    string ChannelName,
+    Guid ConflictingUnitId,
+    string ConflictingUnitType,
+    string ConflictingUnitName,
+    decimal ConflictingFrequency,
+    string ConflictType   // "primary" | "alternate"
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/ConflictSummaryDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/ConflictSummaryDto.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record ConflictSummaryDto(
+    Guid OperationId,
+    int ConflictCount,
+    List<ConflictItemDto> Conflicts
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/CreateRadioChannelRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/CreateRadioChannelRequest.cs
@@ -1,0 +1,7 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record CreateRadioChannelRequest(
+    string Name,
+    string? CallSign,
+    string Scope
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/RadioChannelAssignmentDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/RadioChannelAssignmentDto.cs
@@ -1,0 +1,15 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record RadioChannelAssignmentDto(
+    Guid Id,
+    Guid ChannelId,
+    Guid UnitId,
+    string UnitType,       // "squad" | "platoon" | "faction"
+    string UnitName,
+    decimal? Primary,
+    decimal? Alternate,
+    bool HasConflict,
+    List<string>? ConflictWith,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/RadioChannelDetailDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/RadioChannelDetailDto.cs
@@ -1,0 +1,11 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record RadioChannelDetailDto(
+    Guid Id,
+    Guid EventId,
+    string Name,
+    string? CallSign,
+    string Scope,
+    List<RadioChannelAssignmentDto> Assignments,
+    DateTime CreatedAt
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/RadioChannelListDto.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/RadioChannelListDto.cs
@@ -1,0 +1,10 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record RadioChannelListDto(
+    Guid Id,
+    string Name,
+    string? CallSign,
+    string Scope,
+    int AssignmentCount,
+    int ConflictCount
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Models/Channels/UpdateRadioChannelRequest.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Models/Channels/UpdateRadioChannelRequest.cs
@@ -1,0 +1,6 @@
+namespace MilsimPlanning.Api.Models.Channels;
+
+public record UpdateRadioChannelRequest(
+    string Name,
+    string Scope
+);

--- a/milsim-platform/src/MilsimPlanning.Api/Program.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Program.cs
@@ -126,6 +126,14 @@ builder.Services.AddScoped<FrequencyService>();
 builder.Services.AddScoped<IContentService, ContentService>();
 builder.Services.AddScoped<IMapResourceService, MapResourceService>();
 
+// Radio Channel services (Story 1 + Story 4)
+builder.Services.AddScoped<ChannelAssignmentService>();
+builder.Services.AddScoped<RadioChannelChannelService>();
+builder.Services.AddScoped<NatoFrequencyValidationService>();
+builder.Services.AddScoped<RadioConflictDetectionService>();
+builder.Services.AddScoped<RadioChannelAssignmentService>();
+builder.Services.AddScoped<RadioChannelConflictSummaryService>();
+
 // ── Current User (scoped — one instance per HTTP request) ─────────────────────
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUser, CurrentUserService>();

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -34,10 +34,39 @@ public class ChannelAssignmentService
         var total = await query.CountAsync();
         var items = await query.Skip(offset).Take(limit).ToListAsync();
 
+        // Build conflict-with lists in bulk (no N+1)
+        var conflictedIds = items.Where(a => a.HasConflict).Select(a => a.Id).ToHashSet();
+        var conflictWithMap = new Dictionary<Guid, List<string>>();
+
+        if (conflictedIds.Count > 0)
+        {
+            var radioChannelIds = items.Where(a => a.HasConflict).Select(a => a.RadioChannelId).Distinct().ToList();
+            var relatedAssignments = await _db.ChannelAssignments
+                .Include(a => a.Squad)
+                .Where(a => radioChannelIds.Contains(a.RadioChannelId) && !conflictedIds.Contains(a.Id))
+                .ToListAsync();
+
+            foreach (var a in items.Where(a => a.HasConflict))
+            {
+                var names = relatedAssignments
+                    .Where(x => x.RadioChannelId == a.RadioChannelId
+                             && (x.PrimaryFrequency == a.PrimaryFrequency
+                                 || (a.AlternateFrequency.HasValue && x.PrimaryFrequency == a.AlternateFrequency.Value)
+                                 || (a.AlternateFrequency.HasValue && x.AlternateFrequency.HasValue && x.AlternateFrequency.Value == a.AlternateFrequency.Value)
+                                 || (x.AlternateFrequency.HasValue && x.AlternateFrequency.Value == a.PrimaryFrequency)))
+                    .Select(x => x.Squad.Name)
+                    .Distinct()
+                    .ToList();
+
+                if (names.Count > 0)
+                    conflictWithMap[a.Id] = names;
+            }
+        }
+
         return new ChannelAssignmentListDto
         {
             Total = total,
-            Items = items.Select(ToDto).ToList()
+            Items = items.Select(a => ToDto(a, conflictWithMap.GetValueOrDefault(a.Id))).ToList()
         };
     }
 
@@ -75,10 +104,21 @@ public class ChannelAssignmentService
                 throw new ArgumentException("Alternate frequency cannot match primary frequency");
         }
 
-        // AC-04: Check for frequency conflicts with other units on the same channel
-        await AssertNoFrequencyConflictsAsync(request.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency, excludeAssignmentId: null);
+        // AC-01/02/03: Detect frequency conflicts within operation (channel-scoped = operation-scoped)
+        var conflicts = await DetectFrequencyConflictsAsync(
+            request.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency,
+            excludeAssignmentId: null);
 
+        // AC-04: Advisory mode — if conflicts and no override, return 409 with conflict details
+        if (conflicts.Count > 0 && !request.OverrideConflict)
+        {
+            var first = conflicts[0];
+            throw new FrequencyConflictException(first.ExistingSquadName, first.ConflictingFreq, first.FreqType);
+        }
+
+        var hasConflict = conflicts.Count > 0;
         var now = DateTime.UtcNow;
+
         var assignment = new ChannelAssignment
         {
             Id = Guid.NewGuid(),
@@ -86,6 +126,7 @@ public class ChannelAssignmentService
             SquadId = request.SquadId,
             PrimaryFrequency = request.PrimaryFrequency,
             AlternateFrequency = request.AlternateFrequency,
+            HasConflict = hasConflict,
             EventId = eventId,
             IsDeleted = false,
             CreatedAt = now,
@@ -93,13 +134,41 @@ public class ChannelAssignmentService
         };
 
         _db.ChannelAssignments.Add(assignment);
+
+        // AC-05: Persist conflict records and mark conflicting assignments as conflicted
+        if (hasConflict)
+        {
+            await PersistConflictRecordsAsync(eventId, assignment.SquadId, squad.Name, conflicts);
+
+            var conflictingIds = conflicts.Select(c => c.ExistingAssignmentId).Distinct().ToList();
+            var conflictingAssignments = await _db.ChannelAssignments
+                .Where(a => conflictingIds.Contains(a.Id))
+                .ToListAsync();
+            foreach (var ca in conflictingAssignments)
+            {
+                ca.HasConflict = true;
+                ca.UpdatedAt = now;
+            }
+        }
+
+        // AC-06: Write audit log entry
+        await WriteAuditLogAsync(
+            eventId, "squad", request.SquadId, squad.Name,
+            request.PrimaryFrequency, request.AlternateFrequency,
+            hasConflict ? "created_with_conflict" : "created",
+            hasConflict ? string.Join(", ", conflicts.Select(c => c.ExistingSquadName).Distinct()) : null);
+
         await _db.SaveChangesAsync();
 
         // Reload with navigation properties for DTO mapping
         assignment.RadioChannel = channel;
         assignment.Squad = squad;
 
-        return ToDto(assignment);
+        var conflictWith = hasConflict
+            ? conflicts.Select(c => c.ExistingSquadName).Distinct().ToList()
+            : null;
+
+        return ToDto(assignment, conflictWith);
     }
 
     // ── PUT /api/events/{eventId}/channel-assignments/{id} ───────────────────
@@ -132,16 +201,56 @@ public class ChannelAssignmentService
                 throw new ArgumentException("Alternate frequency cannot match primary frequency");
         }
 
-        // AC-04: Check for frequency conflicts with other units on the same channel (exclude self)
-        await AssertNoFrequencyConflictsAsync(assignment.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency, excludeAssignmentId: assignmentId);
+        // AC-01/02/03: Detect conflicts (exclude self)
+        var conflicts = await DetectFrequencyConflictsAsync(
+            assignment.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency,
+            excludeAssignmentId: assignmentId);
+
+        // AC-04: Advisory mode
+        if (conflicts.Count > 0 && !request.OverrideConflict)
+        {
+            var first = conflicts[0];
+            throw new FrequencyConflictException(first.ExistingSquadName, first.ConflictingFreq, first.FreqType);
+        }
+
+        var hasConflict = conflicts.Count > 0;
+        var now = DateTime.UtcNow;
 
         assignment.PrimaryFrequency = request.PrimaryFrequency;
         assignment.AlternateFrequency = request.AlternateFrequency;
-        assignment.UpdatedAt = DateTime.UtcNow;
+        assignment.HasConflict = hasConflict;
+        assignment.UpdatedAt = now;
+
+        // AC-05: Persist conflict records and mark conflicting assignments
+        if (hasConflict)
+        {
+            await PersistConflictRecordsAsync(eventId, assignment.SquadId, assignment.Squad.Name, conflicts);
+
+            var conflictingIds = conflicts.Select(c => c.ExistingAssignmentId).Distinct().ToList();
+            var conflictingAssignments = await _db.ChannelAssignments
+                .Where(a => conflictingIds.Contains(a.Id))
+                .ToListAsync();
+            foreach (var ca in conflictingAssignments)
+            {
+                ca.HasConflict = true;
+                ca.UpdatedAt = now;
+            }
+        }
+
+        // AC-06: Write audit log entry
+        await WriteAuditLogAsync(
+            eventId, "squad", assignment.SquadId, assignment.Squad.Name,
+            request.PrimaryFrequency, request.AlternateFrequency,
+            hasConflict ? "updated_with_conflict" : "updated",
+            hasConflict ? string.Join(", ", conflicts.Select(c => c.ExistingSquadName).Distinct()) : null);
 
         await _db.SaveChangesAsync();
 
-        return ToDto(assignment);
+        var conflictWith = hasConflict
+            ? conflicts.Select(c => c.ExistingSquadName).Distinct().ToList()
+            : null;
+
+        return ToDto(assignment, conflictWith);
     }
 
     // ── DELETE /api/events/{eventId}/channel-assignments/{id} ────────────────
@@ -158,8 +267,15 @@ public class ChannelAssignmentService
         AssertCommanderAccess(evt.Faction);
 
         var assignment = await _db.ChannelAssignments
+            .Include(a => a.Squad)
             .FirstOrDefaultAsync(a => a.Id == assignmentId && a.EventId == eventId)
             ?? throw new KeyNotFoundException($"ChannelAssignment {assignmentId} not found.");
+
+        // AC-06: Write audit log before soft delete
+        await WriteAuditLogAsync(
+            eventId, "squad", assignment.SquadId, assignment.Squad.Name,
+            assignment.PrimaryFrequency, assignment.AlternateFrequency,
+            "deleted", null);
 
         // Soft delete
         assignment.IsDeleted = true;
@@ -167,44 +283,202 @@ public class ChannelAssignmentService
         await _db.SaveChangesAsync();
     }
 
-    // ── Private helpers ───────────────────────────────────────────────────────
+    // ── GET /api/events/{eventId}/channel-assignments/conflicts ───────────────
 
     /// <summary>
-    /// AC-04: Checks if a primary or alternate frequency conflicts with any existing
-    /// (non-deleted) assignment on the same radio channel. Excludes the calling
-    /// assignment's own record (for updates).
+    /// AC-07: Returns conflict summary for all assignments in the operation.
     /// </summary>
-    private async Task AssertNoFrequencyConflictsAsync(
+    public async Task<ChannelAssignmentConflictSummaryDto> GetConflictsAsync(Guid eventId)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var conflicted = await _db.ChannelAssignments
+            .Include(a => a.RadioChannel)
+            .Include(a => a.Squad)
+            .Where(a => a.EventId == eventId && a.HasConflict)
+            .ToListAsync();
+
+        if (conflicted.Count == 0)
+            return new ChannelAssignmentConflictSummaryDto { EventId = eventId, ConflictCount = 0 };
+
+        // Load all other assignments on same channels to identify counterparts
+        var radioChannelIds = conflicted.Select(a => a.RadioChannelId).Distinct().ToList();
+        var conflictedIdSet = conflicted.Select(a => a.Id).ToHashSet();
+
+        var allOnChannels = await _db.ChannelAssignments
+            .Include(a => a.Squad)
+            .Include(a => a.RadioChannel)
+            .Where(a => radioChannelIds.Contains(a.RadioChannelId) && !conflictedIdSet.Contains(a.Id))
+            .ToListAsync();
+
+        var items = new List<ChannelAssignmentConflictItemDto>();
+
+        foreach (var a in conflicted)
+        {
+            foreach (var other in allOnChannels.Where(x => x.RadioChannelId == a.RadioChannelId))
+            {
+                decimal conflictingFreq;
+                string freqType;
+
+                if (other.PrimaryFrequency == a.PrimaryFrequency)
+                {
+                    conflictingFreq = a.PrimaryFrequency; freqType = "primary";
+                }
+                else if (a.AlternateFrequency.HasValue && other.PrimaryFrequency == a.AlternateFrequency.Value)
+                {
+                    conflictingFreq = a.AlternateFrequency.Value; freqType = "alternate";
+                }
+                else if (a.AlternateFrequency.HasValue && other.AlternateFrequency.HasValue
+                         && other.AlternateFrequency.Value == a.AlternateFrequency.Value)
+                {
+                    conflictingFreq = a.AlternateFrequency.Value; freqType = "alternate";
+                }
+                else if (other.AlternateFrequency.HasValue && other.AlternateFrequency.Value == a.PrimaryFrequency)
+                {
+                    conflictingFreq = a.PrimaryFrequency; freqType = "primary";
+                }
+                else
+                {
+                    continue;
+                }
+
+                items.Add(new ChannelAssignmentConflictItemDto
+                {
+                    AssignmentId = a.Id,
+                    SquadName = a.Squad.Name,
+                    ChannelName = a.RadioChannel.Name,
+                    ConflictingFrequency = conflictingFreq,
+                    FrequencyType = freqType,
+                    ConflictingSquadName = other.Squad.Name
+                });
+            }
+        }
+
+        return new ChannelAssignmentConflictSummaryDto
+        {
+            EventId = eventId,
+            ConflictCount = items.Count,
+            Conflicts = items
+        };
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private record ConflictMatch(
+        Guid ExistingAssignmentId,
+        string ExistingSquadName,
+        decimal ConflictingFreq,
+        string FreqType  // "primary" | "alternate"
+    );
+
+    /// <summary>
+    /// AC-01/02/03: Detect exact-match frequency conflicts within the same radio channel.
+    /// Channel-scoped == operation-scoped (each channel belongs to exactly one event).
+    /// Checks both primary and alternate frequencies.
+    /// </summary>
+    private async Task<List<ConflictMatch>> DetectFrequencyConflictsAsync(
         Guid radioChannelId,
         decimal primaryFrequency,
         decimal? alternateFrequency,
         Guid? excludeAssignmentId)
     {
-        var existingAssignments = await _db.ChannelAssignments
+        var query = _db.ChannelAssignments
             .Include(a => a.Squad)
-            .Where(a => a.RadioChannelId == radioChannelId && !a.IsDeleted)
-            .Where(a => excludeAssignmentId == null || a.Id != excludeAssignmentId.Value)
-            .ToListAsync();
+            .Where(a => a.RadioChannelId == radioChannelId);
 
-        foreach (var existing in existingAssignments)
+        if (excludeAssignmentId.HasValue)
+            query = query.Where(a => a.Id != excludeAssignmentId.Value);
+
+        var existing = await query.ToListAsync();
+        var results = new List<ConflictMatch>();
+
+        foreach (var e in existing)
         {
-            // Check primary frequency against existing primary
-            if (existing.PrimaryFrequency == primaryFrequency)
-                throw new FrequencyConflictException(existing.Squad.Name, primaryFrequency, "primary");
+            // Primary vs existing primary
+            if (e.PrimaryFrequency == primaryFrequency)
+                results.Add(new ConflictMatch(e.Id, e.Squad.Name, primaryFrequency, "primary"));
 
-            // Check primary frequency against existing alternate
-            if (existing.AlternateFrequency.HasValue && existing.AlternateFrequency.Value == primaryFrequency)
-                throw new FrequencyConflictException(existing.Squad.Name, primaryFrequency, "alternate");
+            // Primary vs existing alternate
+            else if (e.AlternateFrequency.HasValue && e.AlternateFrequency.Value == primaryFrequency)
+                results.Add(new ConflictMatch(e.Id, e.Squad.Name, primaryFrequency, "alternate"));
 
-            // Check alternate frequency (if provided) against existing primary
-            if (alternateFrequency.HasValue && existing.PrimaryFrequency == alternateFrequency.Value)
-                throw new FrequencyConflictException(existing.Squad.Name, alternateFrequency.Value, "primary");
+            // Alternate vs existing primary
+            else if (alternateFrequency.HasValue && e.PrimaryFrequency == alternateFrequency.Value)
+                results.Add(new ConflictMatch(e.Id, e.Squad.Name, alternateFrequency.Value, "primary"));
 
-            // Check alternate frequency (if provided) against existing alternate
-            if (alternateFrequency.HasValue && existing.AlternateFrequency.HasValue
-                && existing.AlternateFrequency.Value == alternateFrequency.Value)
-                throw new FrequencyConflictException(existing.Squad.Name, alternateFrequency.Value, "alternate");
+            // Alternate vs existing alternate
+            else if (alternateFrequency.HasValue && e.AlternateFrequency.HasValue
+                     && e.AlternateFrequency.Value == alternateFrequency.Value)
+                results.Add(new ConflictMatch(e.Id, e.Squad.Name, alternateFrequency.Value, "alternate"));
         }
+
+        return results;
+    }
+
+    /// <summary>
+    /// AC-05: Persist FrequencyConflict records when a conflict override is accepted.
+    /// ActionTaken = "overridden" (NOT NULL constraint satisfied).
+    /// </summary>
+    private Task PersistConflictRecordsAsync(
+        Guid eventId,
+        Guid unitAId,
+        string unitAName,
+        List<ConflictMatch> conflicts)
+    {
+        foreach (var conflict in conflicts)
+        {
+            _db.FrequencyConflicts.Add(new FrequencyConflict
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                Frequency = conflict.ConflictingFreq.ToString("F3"),
+                FrequencyType = conflict.FreqType,
+                UnitAType = "squad",
+                UnitAId = unitAId,
+                UnitAName = unitAName,
+                UnitBType = "squad",
+                UnitBId = conflict.ExistingAssignmentId,  // use assignment ID as proxy; UnitB name is stored
+                UnitBName = conflict.ExistingSquadName,
+                Status = "Active",
+                ActionTaken = "overridden",
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// AC-06: Write a frequency audit log entry for every create/update/delete.
+    /// </summary>
+    private async Task WriteAuditLogAsync(
+        Guid eventId,
+        string unitType,
+        Guid unitId,
+        string unitName,
+        decimal? primaryFrequency,
+        decimal? alternateFrequency,
+        string actionType,
+        string? conflictingUnitName)
+    {
+        // Look up display name (best-effort — falls back to UserId string)
+        var profile = await _db.UserProfiles
+            .FirstOrDefaultAsync(p => p.UserId == _currentUser.UserId);
+
+        _db.FrequencyAuditLogs.Add(new FrequencyAuditLog
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            UnitType = unitType,
+            UnitId = unitId,
+            UnitName = unitName,
+            PrimaryFrequency = primaryFrequency?.ToString("F3"),
+            AlternateFrequency = alternateFrequency?.ToString("F3"),
+            ActionType = actionType,
+            ConflictingUnitName = conflictingUnitName,
+            PerformedByUserId = _currentUser.UserId,
+            PerformedByDisplayName = profile?.DisplayName ?? _currentUser.UserId,
+            OccurredAt = DateTime.UtcNow
+        });
     }
 
     private void AssertCommanderAccess(Faction faction)
@@ -213,7 +487,7 @@ public class ChannelAssignmentService
             throw new ForbiddenException("User is not the commander of this event's faction");
     }
 
-    private static ChannelAssignmentDto ToDto(ChannelAssignment a) => new()
+    private static ChannelAssignmentDto ToDto(ChannelAssignment a, List<string>? conflictWith = null) => new()
     {
         Id = a.Id,
         RadioChannelId = a.RadioChannelId,
@@ -223,6 +497,8 @@ public class ChannelAssignmentService
         SquadName = a.Squad.Name,
         PrimaryFrequency = a.PrimaryFrequency,
         AlternateFrequency = a.AlternateFrequency,
+        HasConflict = a.HasConflict,
+        ConflictWith = conflictWith,
         EventId = a.EventId,
         CreatedAt = a.CreatedAt,
         UpdatedAt = a.UpdatedAt

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -1,0 +1,194 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Models.ChannelAssignments;
+
+namespace MilsimPlanning.Api.Services;
+
+public class ChannelAssignmentService
+{
+    private readonly AppDbContext _db;
+    private readonly ICurrentUser _currentUser;
+
+    public ChannelAssignmentService(AppDbContext db, ICurrentUser currentUser)
+    {
+        _db = db;
+        _currentUser = currentUser;
+    }
+
+    // ── GET /api/events/{eventId}/channel-assignments ─────────────────────────
+
+    public async Task<ChannelAssignmentListDto> GetAssignmentsAsync(Guid eventId, int limit, int offset)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var query = _db.ChannelAssignments
+            .Include(a => a.RadioChannel)
+            .Include(a => a.Squad)
+            .Where(a => a.EventId == eventId)
+            .OrderBy(a => a.CreatedAt);
+
+        var total = await query.CountAsync();
+        var items = await query.Skip(offset).Take(limit).ToListAsync();
+
+        return new ChannelAssignmentListDto
+        {
+            Total = total,
+            Items = items.Select(ToDto).ToList()
+        };
+    }
+
+    // ── POST /api/events/{eventId}/channel-assignments ────────────────────────
+
+    public async Task<ChannelAssignmentDto> CreateAssignmentAsync(Guid eventId, CreateChannelAssignmentRequest request)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var evt = await _db.Events
+            .Include(e => e.Faction)
+            .FirstOrDefaultAsync(e => e.Id == eventId)
+            ?? throw new KeyNotFoundException($"Event {eventId} not found.");
+
+        AssertCommanderAccess(evt.Faction);
+
+        // Verify RadioChannel belongs to this event
+        var channel = await _db.RadioChannels
+            .FirstOrDefaultAsync(c => c.Id == request.RadioChannelId && c.EventId == eventId)
+            ?? throw new KeyNotFoundException($"RadioChannel {request.RadioChannelId} not found in event {eventId}.");
+
+        // Verify Squad exists
+        var squad = await _db.Squads
+            .FirstOrDefaultAsync(s => s.Id == request.SquadId)
+            ?? throw new KeyNotFoundException($"Squad {request.SquadId} not found.");
+
+        // Validate frequency against channel scope
+        ValidateFrequency(request.PrimaryFrequency, channel.Scope);
+
+        var now = DateTime.UtcNow;
+        var assignment = new ChannelAssignment
+        {
+            Id = Guid.NewGuid(),
+            RadioChannelId = request.RadioChannelId,
+            SquadId = request.SquadId,
+            PrimaryFrequency = request.PrimaryFrequency,
+            EventId = eventId,
+            IsDeleted = false,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        _db.ChannelAssignments.Add(assignment);
+        await _db.SaveChangesAsync();
+
+        // Reload with navigation properties for DTO mapping
+        assignment.RadioChannel = channel;
+        assignment.Squad = squad;
+
+        return ToDto(assignment);
+    }
+
+    // ── PUT /api/events/{eventId}/channel-assignments/{id} ───────────────────
+
+    public async Task<ChannelAssignmentDto> UpdateAssignmentAsync(Guid eventId, Guid assignmentId, UpdateChannelAssignmentRequest request)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var evt = await _db.Events
+            .Include(e => e.Faction)
+            .FirstOrDefaultAsync(e => e.Id == eventId)
+            ?? throw new KeyNotFoundException($"Event {eventId} not found.");
+
+        AssertCommanderAccess(evt.Faction);
+
+        var assignment = await _db.ChannelAssignments
+            .Include(a => a.RadioChannel)
+            .Include(a => a.Squad)
+            .FirstOrDefaultAsync(a => a.Id == assignmentId && a.EventId == eventId)
+            ?? throw new KeyNotFoundException($"ChannelAssignment {assignmentId} not found.");
+
+        // Validate frequency against channel scope
+        ValidateFrequency(request.PrimaryFrequency, assignment.RadioChannel.Scope);
+
+        assignment.PrimaryFrequency = request.PrimaryFrequency;
+        assignment.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+
+        return ToDto(assignment);
+    }
+
+    // ── DELETE /api/events/{eventId}/channel-assignments/{id} ────────────────
+
+    public async Task DeleteAssignmentAsync(Guid eventId, Guid assignmentId)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var evt = await _db.Events
+            .Include(e => e.Faction)
+            .FirstOrDefaultAsync(e => e.Id == eventId)
+            ?? throw new KeyNotFoundException($"Event {eventId} not found.");
+
+        AssertCommanderAccess(evt.Faction);
+
+        var assignment = await _db.ChannelAssignments
+            .FirstOrDefaultAsync(a => a.Id == assignmentId && a.EventId == eventId)
+            ?? throw new KeyNotFoundException($"ChannelAssignment {assignmentId} not found.");
+
+        // Soft delete
+        assignment.IsDeleted = true;
+        assignment.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+    }
+
+    // ── Frequency validation ──────────────────────────────────────────────────
+
+    internal static void ValidateFrequency(decimal frequency, ChannelScope scope)
+    {
+        bool validRange = scope switch
+        {
+            ChannelScope.VHF => frequency >= 30.0M && frequency <= 87.975M,
+            ChannelScope.UHF => frequency >= 225.0M && frequency <= 400.0M,
+            _ => throw new ArgumentException($"Unknown channel scope: {scope}")
+        };
+
+        if (!validRange)
+        {
+            var rangeMsg = scope == ChannelScope.VHF
+                ? "VHF accepts 30.0–87.975 MHz"
+                : "UHF accepts 225–400 MHz";
+            throw new ArgumentException(
+                $"Frequency {frequency} MHz is out of range for {scope}. {rangeMsg}.");
+        }
+
+        // 25 kHz spacing check
+        var remainder = Math.Abs(frequency % 0.025M);
+        var alignmentError = Math.Min(remainder, Math.Abs(remainder - 0.025M));
+        if (alignmentError > 0.0001M)
+            throw new ArgumentException(
+                $"Frequency {frequency} MHz does not align to 25 kHz spacing. " +
+                "Frequency must be a multiple of 0.025 MHz (e.g., 30.025, 30.050).");
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private void AssertCommanderAccess(Faction faction)
+    {
+        if (faction.CommanderId != _currentUser.UserId)
+            throw new ForbiddenException("User is not the commander of this event's faction");
+    }
+
+    private static ChannelAssignmentDto ToDto(ChannelAssignment a) => new()
+    {
+        Id = a.Id,
+        RadioChannelId = a.RadioChannelId,
+        ChannelName = a.RadioChannel.Name,
+        ChannelScope = a.RadioChannel.Scope.ToString(),
+        SquadId = a.SquadId,
+        SquadName = a.Squad.Name,
+        PrimaryFrequency = a.PrimaryFrequency,
+        EventId = a.EventId,
+        CreatedAt = a.CreatedAt,
+        UpdatedAt = a.UpdatedAt
+    };
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -67,6 +67,14 @@ public class ChannelAssignmentService
         // Validate frequency against channel scope
         _validator.Validate(request.PrimaryFrequency, channel.Scope);
 
+        // Validate alternate frequency if provided
+        if (request.AlternateFrequency.HasValue)
+        {
+            _validator.Validate(request.AlternateFrequency.Value, channel.Scope);
+            if (request.AlternateFrequency.Value == request.PrimaryFrequency)
+                throw new ArgumentException("Alternate frequency cannot match primary frequency");
+        }
+
         var now = DateTime.UtcNow;
         var assignment = new ChannelAssignment
         {
@@ -74,6 +82,7 @@ public class ChannelAssignmentService
             RadioChannelId = request.RadioChannelId,
             SquadId = request.SquadId,
             PrimaryFrequency = request.PrimaryFrequency,
+            AlternateFrequency = request.AlternateFrequency,
             EventId = eventId,
             IsDeleted = false,
             CreatedAt = now,
@@ -112,7 +121,16 @@ public class ChannelAssignmentService
         // Validate frequency against channel scope
         _validator.Validate(request.PrimaryFrequency, assignment.RadioChannel.Scope);
 
+        // Validate alternate frequency if provided
+        if (request.AlternateFrequency.HasValue)
+        {
+            _validator.Validate(request.AlternateFrequency.Value, assignment.RadioChannel.Scope);
+            if (request.AlternateFrequency.Value == request.PrimaryFrequency)
+                throw new ArgumentException("Alternate frequency cannot match primary frequency");
+        }
+
         assignment.PrimaryFrequency = request.PrimaryFrequency;
+        assignment.AlternateFrequency = request.AlternateFrequency;
         assignment.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync();
@@ -160,6 +178,7 @@ public class ChannelAssignmentService
         SquadId = a.SquadId,
         SquadName = a.Squad.Name,
         PrimaryFrequency = a.PrimaryFrequency,
+        AlternateFrequency = a.AlternateFrequency,
         EventId = a.EventId,
         CreatedAt = a.CreatedAt,
         UpdatedAt = a.UpdatedAt

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -10,11 +10,13 @@ public class ChannelAssignmentService
 {
     private readonly AppDbContext _db;
     private readonly ICurrentUser _currentUser;
+    private readonly NatoFrequencyValidationService _validator;
 
-    public ChannelAssignmentService(AppDbContext db, ICurrentUser currentUser)
+    public ChannelAssignmentService(AppDbContext db, ICurrentUser currentUser, NatoFrequencyValidationService validator)
     {
         _db = db;
         _currentUser = currentUser;
+        _validator = validator;
     }
 
     // ── GET /api/events/{eventId}/channel-assignments ─────────────────────────
@@ -63,7 +65,7 @@ public class ChannelAssignmentService
             ?? throw new KeyNotFoundException($"Squad {request.SquadId} not found.");
 
         // Validate frequency against channel scope
-        ValidateFrequency(request.PrimaryFrequency, channel.Scope);
+        _validator.Validate(request.PrimaryFrequency, channel.Scope);
 
         var now = DateTime.UtcNow;
         var assignment = new ChannelAssignment
@@ -108,7 +110,7 @@ public class ChannelAssignmentService
             ?? throw new KeyNotFoundException($"ChannelAssignment {assignmentId} not found.");
 
         // Validate frequency against channel scope
-        ValidateFrequency(request.PrimaryFrequency, assignment.RadioChannel.Scope);
+        _validator.Validate(request.PrimaryFrequency, assignment.RadioChannel.Scope);
 
         assignment.PrimaryFrequency = request.PrimaryFrequency;
         assignment.UpdatedAt = DateTime.UtcNow;
@@ -139,35 +141,6 @@ public class ChannelAssignmentService
         assignment.IsDeleted = true;
         assignment.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
-    }
-
-    // ── Frequency validation ──────────────────────────────────────────────────
-
-    internal static void ValidateFrequency(decimal frequency, ChannelScope scope)
-    {
-        bool validRange = scope switch
-        {
-            ChannelScope.VHF => frequency >= 30.0M && frequency <= 87.975M,
-            ChannelScope.UHF => frequency >= 225.0M && frequency <= 400.0M,
-            _ => throw new ArgumentException($"Unknown channel scope: {scope}")
-        };
-
-        if (!validRange)
-        {
-            var rangeMsg = scope == ChannelScope.VHF
-                ? "VHF accepts 30.0–87.975 MHz"
-                : "UHF accepts 225–400 MHz";
-            throw new ArgumentException(
-                $"Frequency {frequency} MHz is out of range for {scope}. {rangeMsg}.");
-        }
-
-        // 25 kHz spacing check
-        var remainder = Math.Abs(frequency % 0.025M);
-        var alignmentError = Math.Min(remainder, Math.Abs(remainder - 0.025M));
-        if (alignmentError > 0.0001M)
-            throw new ArgumentException(
-                $"Frequency {frequency} MHz does not align to 25 kHz spacing. " +
-                "Frequency must be a multiple of 0.025 MHz (e.g., 30.025, 30.050).");
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/ChannelAssignmentService.cs
@@ -75,6 +75,9 @@ public class ChannelAssignmentService
                 throw new ArgumentException("Alternate frequency cannot match primary frequency");
         }
 
+        // AC-04: Check for frequency conflicts with other units on the same channel
+        await AssertNoFrequencyConflictsAsync(request.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency, excludeAssignmentId: null);
+
         var now = DateTime.UtcNow;
         var assignment = new ChannelAssignment
         {
@@ -129,6 +132,9 @@ public class ChannelAssignmentService
                 throw new ArgumentException("Alternate frequency cannot match primary frequency");
         }
 
+        // AC-04: Check for frequency conflicts with other units on the same channel (exclude self)
+        await AssertNoFrequencyConflictsAsync(assignment.RadioChannelId, request.PrimaryFrequency, request.AlternateFrequency, excludeAssignmentId: assignmentId);
+
         assignment.PrimaryFrequency = request.PrimaryFrequency;
         assignment.AlternateFrequency = request.AlternateFrequency;
         assignment.UpdatedAt = DateTime.UtcNow;
@@ -162,6 +168,44 @@ public class ChannelAssignmentService
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// AC-04: Checks if a primary or alternate frequency conflicts with any existing
+    /// (non-deleted) assignment on the same radio channel. Excludes the calling
+    /// assignment's own record (for updates).
+    /// </summary>
+    private async Task AssertNoFrequencyConflictsAsync(
+        Guid radioChannelId,
+        decimal primaryFrequency,
+        decimal? alternateFrequency,
+        Guid? excludeAssignmentId)
+    {
+        var existingAssignments = await _db.ChannelAssignments
+            .Include(a => a.Squad)
+            .Where(a => a.RadioChannelId == radioChannelId && !a.IsDeleted)
+            .Where(a => excludeAssignmentId == null || a.Id != excludeAssignmentId.Value)
+            .ToListAsync();
+
+        foreach (var existing in existingAssignments)
+        {
+            // Check primary frequency against existing primary
+            if (existing.PrimaryFrequency == primaryFrequency)
+                throw new FrequencyConflictException(existing.Squad.Name, primaryFrequency, "primary");
+
+            // Check primary frequency against existing alternate
+            if (existing.AlternateFrequency.HasValue && existing.AlternateFrequency.Value == primaryFrequency)
+                throw new FrequencyConflictException(existing.Squad.Name, primaryFrequency, "alternate");
+
+            // Check alternate frequency (if provided) against existing primary
+            if (alternateFrequency.HasValue && existing.PrimaryFrequency == alternateFrequency.Value)
+                throw new FrequencyConflictException(existing.Squad.Name, alternateFrequency.Value, "primary");
+
+            // Check alternate frequency (if provided) against existing alternate
+            if (alternateFrequency.HasValue && existing.AlternateFrequency.HasValue
+                && existing.AlternateFrequency.Value == alternateFrequency.Value)
+                throw new FrequencyConflictException(existing.Squad.Name, alternateFrequency.Value, "alternate");
+        }
+    }
 
     private void AssertCommanderAccess(Faction faction)
     {

--- a/milsim-platform/src/MilsimPlanning.Api/Services/NatoFrequencyValidationService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/NatoFrequencyValidationService.cs
@@ -3,14 +3,14 @@ using MilsimPlanning.Api.Data.Entities;
 namespace MilsimPlanning.Api.Services;
 
 /// <summary>
-/// Validates NATO radio frequencies for VHF (30.0–69.975 MHz) and UHF (225.0–400.0 MHz)
+/// Validates NATO radio frequencies for VHF (30.0–87.975 MHz) and UHF (225.0–400.0 MHz)
 /// with mandatory 25 kHz channel spacing.
 /// </summary>
 public class NatoFrequencyValidationService
 {
-    // VHF: 30.000–69.975 MHz (25 kHz spacing)
+    // VHF: 30.000–87.975 MHz (25 kHz spacing)
     private const decimal VhfMin = 30.000m;
-    private const decimal VhfMax = 69.975m;
+    private const decimal VhfMax = 87.975m;
 
     // UHF: 225.000–400.000 MHz (25 kHz spacing)
     private const decimal UhfMin = 225.000m;
@@ -27,7 +27,7 @@ public class NatoFrequencyValidationService
 
         var (min, max, label) = scope switch
         {
-            ChannelScope.VHF => (VhfMin, VhfMax, "VHF (30.0–69.975 MHz)"),
+            ChannelScope.VHF => (VhfMin, VhfMax, "VHF (30.0–87.975 MHz)"),
             ChannelScope.UHF => (UhfMin, UhfMax, "UHF (225.0–400.0 MHz)"),
             _ => throw new ArgumentException($"Unknown channel scope: {scope}")
         };

--- a/milsim-platform/src/MilsimPlanning.Api/Services/NatoFrequencyValidationService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/NatoFrequencyValidationService.cs
@@ -1,0 +1,46 @@
+using MilsimPlanning.Api.Data.Entities;
+
+namespace MilsimPlanning.Api.Services;
+
+/// <summary>
+/// Validates NATO radio frequencies for VHF (30.0–69.975 MHz) and UHF (225.0–400.0 MHz)
+/// with mandatory 25 kHz channel spacing.
+/// </summary>
+public class NatoFrequencyValidationService
+{
+    // VHF: 30.000–69.975 MHz (25 kHz spacing)
+    private const decimal VhfMin = 30.000m;
+    private const decimal VhfMax = 69.975m;
+
+    // UHF: 225.000–400.000 MHz (25 kHz spacing)
+    private const decimal UhfMin = 225.000m;
+    private const decimal UhfMax = 400.000m;
+
+    /// <summary>
+    /// Validates that a frequency is within NATO range for the given scope and aligns to 25 kHz.
+    /// Throws <see cref="ArgumentException"/> if invalid and <paramref name="overrideValidation"/> is false.
+    /// If <paramref name="overrideValidation"/> is true, validation is skipped.
+    /// </summary>
+    public void Validate(decimal frequency, ChannelScope scope, bool overrideValidation = false)
+    {
+        if (overrideValidation) return;
+
+        var (min, max, label) = scope switch
+        {
+            ChannelScope.VHF => (VhfMin, VhfMax, "VHF (30.0–69.975 MHz)"),
+            ChannelScope.UHF => (UhfMin, UhfMax, "UHF (225.0–400.0 MHz)"),
+            _ => throw new ArgumentException($"Unknown channel scope: {scope}")
+        };
+
+        if (frequency < min || frequency > max)
+            throw new ArgumentException(
+                $"Frequency {frequency} MHz is out of range for {label}.");
+
+        // 25 kHz alignment check: (freq * 1000) % 25 == 0
+        var thousandths = Math.Round(frequency * 1000m);
+        if (thousandths % 25 != 0)
+            throw new ArgumentException(
+                $"Frequency {frequency} MHz does not align to 25 kHz spacing. " +
+                "Must be a multiple of 0.025 MHz (e.g. 36.500, 36.525).");
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Services/RadioChannelAssignmentService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/RadioChannelAssignmentService.cs
@@ -1,0 +1,297 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Models.Channels;
+
+namespace MilsimPlanning.Api.Services;
+
+/// <summary>
+/// Orchestrates validation, conflict detection, and persistence for
+/// RadioChannelAssignment (Story 4 — AC-01 through AC-07).
+/// </summary>
+public class RadioChannelAssignmentService
+{
+    private readonly AppDbContext _db;
+    private readonly ICurrentUser _currentUser;
+    private readonly NatoFrequencyValidationService _validator;
+    private readonly RadioConflictDetectionService _conflictDetector;
+
+    public RadioChannelAssignmentService(
+        AppDbContext db,
+        ICurrentUser currentUser,
+        NatoFrequencyValidationService validator,
+        RadioConflictDetectionService conflictDetector)
+    {
+        _db = db;
+        _currentUser = currentUser;
+        _validator = validator;
+        _conflictDetector = conflictDetector;
+    }
+
+    // ── GET /api/radio-channels/{channelId}/assignments ───────────────────────
+
+    public async Task<List<RadioChannelAssignmentDto>> GetAssignmentsAsync(Guid channelId)
+    {
+        var channel = await _db.RadioChannels
+            .FirstOrDefaultAsync(rc => rc.Id == channelId)
+            ?? throw new KeyNotFoundException($"RadioChannel {channelId} not found.");
+
+        ScopeGuard.AssertEventAccess(_currentUser, channel.EventId);
+
+        var assignments = await _db.RadioChannelAssignments
+            .Include(a => a.Squad)
+            .Include(a => a.Platoon)
+            .Include(a => a.Faction)
+            .Where(a => a.ChannelId == channelId)
+            .ToListAsync();
+
+        // Build conflict-with info for each assignment
+        var dtos = new List<RadioChannelAssignmentDto>();
+        foreach (var a in assignments)
+        {
+            var conflictWith = await BuildConflictWithAsync(a);
+            dtos.Add(ToDto(a, conflictWith));
+        }
+
+        return dtos;
+    }
+
+    // ── PUT /api/radio-channels/{channelId}/assignments/{unitType}/{unitId} ───
+    // AC-01/02: conflict detection for primary AND alternate
+    // AC-04: advisory mode — throw InvalidOperationException if conflict and !override
+    // AC-05: persist HasConflict flag
+
+    public async Task<RadioChannelAssignmentDto> UpsertAssignmentAsync(
+        Guid channelId,
+        string unitType,
+        Guid unitId,
+        AssignFrequencyRequest request)
+    {
+        var channel = await _db.RadioChannels
+            .Include(rc => rc.Event)
+                .ThenInclude(e => e.Faction)
+            .FirstOrDefaultAsync(rc => rc.Id == channelId)
+            ?? throw new KeyNotFoundException($"RadioChannel {channelId} not found.");
+
+        ScopeGuard.AssertEventAccess(_currentUser, channel.EventId);
+        AssertCommanderAccess(channel.Event.Faction);
+
+        // Resolve unit and validate it exists
+        var (squadId, platoonId, factionId, _) =
+            await ResolveUnitAsync(unitType, unitId, channel.EventId);
+
+        // Validate frequencies (AC-01/02)
+        if (request.Primary.HasValue)
+            _validator.Validate(request.Primary.Value, channel.Scope, request.OverrideValidation);
+        if (request.Alternate.HasValue)
+            _validator.Validate(request.Alternate.Value, channel.Scope, request.OverrideValidation);
+
+        // Find existing assignment for this unit on this channel
+        var existing = await _db.RadioChannelAssignments
+            .FirstOrDefaultAsync(a =>
+                a.ChannelId == channelId
+                && a.SquadId == squadId
+                && a.PlatoonId == platoonId
+                && a.FactionId == factionId);
+
+        // Conflict detection (AC-01/02/03)
+        var allConflicts = new List<ConflictInfo>();
+
+        if (request.Primary.HasValue)
+        {
+            var conflicts = await _conflictDetector.DetectConflictsAsync(
+                channelId, request.Primary.Value, existing?.Id);
+            allConflicts.AddRange(conflicts);
+        }
+
+        if (request.Alternate.HasValue)
+        {
+            var conflicts = await _conflictDetector.DetectConflictsAsync(
+                channelId, request.Alternate.Value, existing?.Id);
+            allConflicts.AddRange(conflicts);
+        }
+
+        // AC-04: advisory — if conflicts and no override, throw 409
+        if (allConflicts.Count > 0 && !request.OverrideValidation)
+        {
+            var detail = string.Join("; ", allConflicts.Select(c =>
+                $"{c.UnitName} ({c.UnitType}) uses {c.Frequency} MHz as {c.ConflictType}"));
+            throw new InvalidOperationException(
+                $"Frequency conflict detected with: {detail}");
+        }
+
+        var hasConflict = allConflicts.Count > 0;
+        var now = DateTime.UtcNow;
+
+        if (existing is null)
+        {
+            existing = new RadioChannelAssignment
+            {
+                Id = Guid.NewGuid(),
+                ChannelId = channelId,
+                SquadId = squadId,
+                PlatoonId = platoonId,
+                FactionId = factionId,
+                Primary = request.Primary,
+                Alternate = request.Alternate,
+                HasConflict = hasConflict,
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+            _db.RadioChannelAssignments.Add(existing);
+        }
+        else
+        {
+            existing.Primary = request.Primary;
+            existing.Alternate = request.Alternate;
+            existing.HasConflict = hasConflict;
+            existing.UpdatedAt = now;
+        }
+
+        // AC-05: update HasConflict on all other conflicting assignments too
+        if (hasConflict)
+        {
+            var conflictingIds = allConflicts.Select(c => c.AssignmentId).Distinct().ToList();
+            var conflictingAssignments = await _db.RadioChannelAssignments
+                .Where(a => conflictingIds.Contains(a.Id))
+                .ToListAsync();
+
+            foreach (var ca in conflictingAssignments)
+            {
+                ca.HasConflict = true;
+                ca.UpdatedAt = now;
+            }
+        }
+
+        await _db.SaveChangesAsync();
+
+        // Reload with navigation properties
+        await _db.Entry(existing).Reference(a => a.Channel).LoadAsync();
+        if (existing.SquadId.HasValue)
+            await _db.Entry(existing).Reference(a => a.Squad).LoadAsync();
+        if (existing.PlatoonId.HasValue)
+            await _db.Entry(existing).Reference(a => a.Platoon).LoadAsync();
+        if (existing.FactionId.HasValue)
+            await _db.Entry(existing).Reference(a => a.Faction).LoadAsync();
+
+        var conflictWith = await BuildConflictWithAsync(existing);
+        return ToDto(existing, conflictWith);
+    }
+
+    // ── DELETE /api/radio-channels/{channelId}/assignments/{unitType}/{unitId} ─
+
+    public async Task DeleteAssignmentAsync(Guid channelId, string unitType, Guid unitId)
+    {
+        var channel = await _db.RadioChannels
+            .Include(rc => rc.Event)
+                .ThenInclude(e => e.Faction)
+            .FirstOrDefaultAsync(rc => rc.Id == channelId)
+            ?? throw new KeyNotFoundException($"RadioChannel {channelId} not found.");
+
+        ScopeGuard.AssertEventAccess(_currentUser, channel.EventId);
+        AssertCommanderAccess(channel.Event.Faction);
+
+        var (squadId, platoonId, factionId, _) =
+            await ResolveUnitAsync(unitType, unitId, channel.EventId);
+
+        var assignment = await _db.RadioChannelAssignments
+            .FirstOrDefaultAsync(a =>
+                a.ChannelId == channelId
+                && a.SquadId == squadId
+                && a.PlatoonId == platoonId
+                && a.FactionId == factionId)
+            ?? throw new KeyNotFoundException(
+                $"Assignment for {unitType} {unitId} on channel {channelId} not found.");
+
+        _db.RadioChannelAssignments.Remove(assignment);
+        await _db.SaveChangesAsync();
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private void AssertCommanderAccess(Faction faction)
+    {
+        if (faction.CommanderId != _currentUser.UserId)
+            throw new ForbiddenException("User is not the commander of this event's faction");
+    }
+
+    private async Task<(Guid? squadId, Guid? platoonId, Guid? factionId, string unitName)>
+        ResolveUnitAsync(string unitType, Guid unitId, Guid eventId)
+    {
+        return unitType.ToLowerInvariant() switch
+        {
+            "squad" => await ResolveSquadAsync(unitId),
+            "platoon" => await ResolvePlatoonAsync(unitId),
+            "faction" => await ResolveFactionAsync(unitId),
+            _ => throw new ArgumentException($"Unknown unit type '{unitType}'. Must be squad, platoon, or faction.")
+        };
+    }
+
+    private async Task<(Guid?, Guid?, Guid?, string)> ResolveSquadAsync(Guid id)
+    {
+        var squad = await _db.Squads.FirstOrDefaultAsync(s => s.Id == id)
+            ?? throw new KeyNotFoundException($"Squad {id} not found.");
+        return (squad.Id, null, null, squad.Name);
+    }
+
+    private async Task<(Guid?, Guid?, Guid?, string)> ResolvePlatoonAsync(Guid id)
+    {
+        var platoon = await _db.Platoons.FirstOrDefaultAsync(p => p.Id == id)
+            ?? throw new KeyNotFoundException($"Platoon {id} not found.");
+        return (null, platoon.Id, null, platoon.Name);
+    }
+
+    private async Task<(Guid?, Guid?, Guid?, string)> ResolveFactionAsync(Guid id)
+    {
+        var faction = await _db.Factions.FirstOrDefaultAsync(f => f.Id == id)
+            ?? throw new KeyNotFoundException($"Faction {id} not found.");
+        return (null, null, faction.Id, faction.Name);
+    }
+
+    private async Task<List<string>?> BuildConflictWithAsync(RadioChannelAssignment a)
+    {
+        if (!a.HasConflict) return null;
+
+        var conflicts = new List<string>();
+
+        if (a.Primary.HasValue)
+        {
+            var c = await _conflictDetector.DetectConflictsAsync(a.ChannelId, a.Primary.Value, a.Id);
+            conflicts.AddRange(c.Select(x => $"{x.UnitName} ({x.UnitType}) — {x.Frequency} MHz"));
+        }
+
+        if (a.Alternate.HasValue)
+        {
+            var c = await _conflictDetector.DetectConflictsAsync(a.ChannelId, a.Alternate.Value, a.Id);
+            conflicts.AddRange(c.Select(x => $"{x.UnitName} ({x.UnitType}) — {x.Frequency} MHz"));
+        }
+
+        return conflicts.Count > 0 ? conflicts : null;
+    }
+
+    private static RadioChannelAssignmentDto ToDto(RadioChannelAssignment a, List<string>? conflictWith)
+    {
+        var (unitId, unitType, unitName) = a switch
+        {
+            { Squad: not null }   => (a.Squad.Id,   "squad",   a.Squad.Name),
+            { Platoon: not null } => (a.Platoon.Id, "platoon", a.Platoon.Name),
+            { Faction: not null } => (a.Faction.Id, "faction", a.Faction.Name),
+            _ => (a.SquadId ?? a.PlatoonId ?? a.FactionId ?? Guid.Empty, "unknown", "unknown")
+        };
+
+        return new RadioChannelAssignmentDto(
+            a.Id,
+            a.ChannelId,
+            unitId,
+            unitType,
+            unitName,
+            a.Primary,
+            a.Alternate,
+            a.HasConflict,
+            conflictWith,
+            a.CreatedAt,
+            a.UpdatedAt
+        );
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Services/RadioChannelChannelService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/RadioChannelChannelService.cs
@@ -1,0 +1,157 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Models.Channels;
+
+namespace MilsimPlanning.Api.Services;
+
+/// <summary>
+/// Channel CRUD for Story 4 endpoints — returns new DTOs from Models/Channels/.
+/// Complements the existing RadioChannelService (which returns Models/RadioChannels/ DTOs).
+/// </summary>
+public class RadioChannelChannelService
+{
+    private readonly AppDbContext _db;
+    private readonly ICurrentUser _currentUser;
+
+    public RadioChannelChannelService(AppDbContext db, ICurrentUser currentUser)
+    {
+        _db = db;
+        _currentUser = currentUser;
+    }
+
+    // ── GET /api/events/{eventId}/radio-channels ─────────────────────────────
+
+    public async Task<List<RadioChannelListDto>> ListAsync(Guid eventId)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var channels = await _db.RadioChannels
+            .Include(rc => rc.Assignments)
+            .Where(rc => rc.EventId == eventId && !rc.IsDeleted)
+            .OrderBy(rc => rc.Order)
+            .ToListAsync();
+
+        return channels.Select(rc => new RadioChannelListDto(
+            rc.Id,
+            rc.Name,
+            rc.CallSign,
+            rc.Scope.ToString(),
+            rc.Assignments.Count,
+            rc.Assignments.Count(a => a.HasConflict)
+        )).ToList();
+    }
+
+    // ── POST /api/events/{eventId}/radio-channels ─────────────────────────────
+
+    public async Task<RadioChannelDetailDto> CreateAsync(Guid eventId, CreateRadioChannelRequest request)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        var evt = await _db.Events
+            .Include(e => e.Faction)
+            .FirstOrDefaultAsync(e => e.Id == eventId)
+            ?? throw new KeyNotFoundException($"Event {eventId} not found.");
+
+        AssertCommanderAccess(evt.Faction);
+
+        var scope = ParseScope(request.Scope);
+
+        // Validate uniqueness within event
+        var duplicate = await _db.RadioChannels
+            .AnyAsync(rc => rc.EventId == eventId && rc.Name == request.Name.Trim() && !rc.IsDeleted);
+
+        if (duplicate)
+            throw new InvalidOperationException("Channel name already exists in this operation.");
+
+        var order = await _db.RadioChannels
+            .Where(rc => rc.EventId == eventId && !rc.IsDeleted)
+            .Select(rc => (int?)rc.Order)
+            .MaxAsync() ?? -1;
+
+        var now = DateTime.UtcNow;
+
+        var channel = new RadioChannel
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            Name = request.Name.Trim(),
+            CallSign = request.CallSign?.Trim(),
+            Scope = scope,
+            Order = order + 1,
+            IsDeleted = false
+        };
+
+        _db.RadioChannels.Add(channel);
+        await _db.SaveChangesAsync();
+
+        return new RadioChannelDetailDto(
+            channel.Id,
+            channel.EventId,
+            channel.Name,
+            channel.CallSign,
+            channel.Scope.ToString(),
+            [],
+            now
+        );
+    }
+
+    // ── PATCH /api/radio-channels/{channelId} ─────────────────────────────────
+
+    public async Task<RadioChannelDetailDto> UpdateAsync(Guid channelId, UpdateRadioChannelRequest request)
+    {
+        var channel = await _db.RadioChannels
+            .Include(rc => rc.Event)
+                .ThenInclude(e => e.Faction)
+            .Include(rc => rc.Assignments)
+            .FirstOrDefaultAsync(rc => rc.Id == channelId && !rc.IsDeleted)
+            ?? throw new KeyNotFoundException($"Channel {channelId} not found.");
+
+        ScopeGuard.AssertEventAccess(_currentUser, channel.EventId);
+        AssertCommanderAccess(channel.Event.Faction);
+
+        var scope = ParseScope(request.Scope);
+        var trimmedName = request.Name.Trim();
+
+        // Validate uniqueness within event (exclude self)
+        var duplicate = await _db.RadioChannels
+            .AnyAsync(rc => rc.EventId == channel.EventId
+                         && rc.Name == trimmedName
+                         && rc.Id != channelId
+                         && !rc.IsDeleted);
+
+        if (duplicate)
+            throw new InvalidOperationException("Channel name already exists in this operation.");
+
+        channel.Name = trimmedName;
+        channel.Scope = scope;
+        await _db.SaveChangesAsync();
+
+        return new RadioChannelDetailDto(
+            channel.Id,
+            channel.EventId,
+            channel.Name,
+            channel.CallSign,
+            channel.Scope.ToString(),
+            [],
+            DateTime.UtcNow
+        );
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private void AssertCommanderAccess(Faction faction)
+    {
+        if (faction.CommanderId != _currentUser.UserId)
+            throw new ForbiddenException("User is not the commander of this event's faction");
+    }
+
+    private static ChannelScope ParseScope(string scope) =>
+        scope.ToUpperInvariant() switch
+        {
+            "VHF" => ChannelScope.VHF,
+            "UHF" => ChannelScope.UHF,
+            _ => throw new ArgumentException($"Invalid scope '{scope}'. Must be 'VHF' or 'UHF'.")
+        };
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Services/RadioChannelConflictSummaryService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/RadioChannelConflictSummaryService.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Authorization;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+using MilsimPlanning.Api.Models.Channels;
+
+namespace MilsimPlanning.Api.Services;
+
+/// <summary>
+/// Builds the conflict summary for an operation (AC-07).
+/// Returns all active RadioChannelAssignment conflicts scoped to the event.
+/// </summary>
+public class RadioChannelConflictSummaryService
+{
+    private readonly AppDbContext _db;
+    private readonly ICurrentUser _currentUser;
+
+    public RadioChannelConflictSummaryService(AppDbContext db, ICurrentUser currentUser)
+    {
+        _db = db;
+        _currentUser = currentUser;
+    }
+
+    public async Task<ConflictSummaryDto> GetConflictSummaryAsync(Guid eventId)
+    {
+        ScopeGuard.AssertEventAccess(_currentUser, eventId);
+
+        // Load all conflicted assignments for channels belonging to this event
+        var conflictedAssignments = await _db.RadioChannelAssignments
+            .Include(a => a.Channel)
+            .Include(a => a.Squad)
+            .Include(a => a.Platoon)
+            .Include(a => a.Faction)
+            .Where(a => a.HasConflict && a.Channel.EventId == eventId)
+            .ToListAsync();
+
+        var conflictItems = new List<ConflictItemDto>();
+
+        foreach (var a in conflictedAssignments)
+        {
+            await AddConflictItemsAsync(a, conflictItems);
+        }
+
+        return new ConflictSummaryDto(eventId, conflictItems.Count, conflictItems);
+    }
+
+    private async Task AddConflictItemsAsync(
+        RadioChannelAssignment assignment,
+        List<ConflictItemDto> items)
+    {
+        var freqs = new List<(decimal freq, string type)>();
+        if (assignment.Primary.HasValue) freqs.Add((assignment.Primary.Value, "primary"));
+        if (assignment.Alternate.HasValue) freqs.Add((assignment.Alternate.Value, "alternate"));
+
+        foreach (var (freq, freqType) in freqs)
+        {
+            var conflicts = await _db.RadioChannelAssignments
+                .Include(a => a.Squad)
+                .Include(a => a.Platoon)
+                .Include(a => a.Faction)
+                .Where(a =>
+                    a.Id != assignment.Id
+                    && a.ChannelId == assignment.ChannelId
+                    && (a.Primary == freq || a.Alternate == freq))
+                .ToListAsync();
+
+            foreach (var conflicting in conflicts)
+            {
+                var (cUnitId, cUnitType, cUnitName) = ResolveUnit(conflicting);
+
+                items.Add(new ConflictItemDto(
+                    assignment.Id,
+                    assignment.Channel.Name,
+                    cUnitId,
+                    cUnitType,
+                    cUnitName,
+                    freq,
+                    freqType
+                ));
+            }
+        }
+    }
+
+    private static (Guid unitId, string unitType, string unitName) ResolveUnit(RadioChannelAssignment a)
+    {
+        if (a.Squad != null) return (a.Squad.Id, "squad", a.Squad.Name);
+        if (a.Platoon != null) return (a.Platoon.Id, "platoon", a.Platoon.Name);
+        if (a.Faction != null) return (a.Faction.Id, "faction", a.Faction.Name);
+        return (Guid.Empty, "unknown", "unknown");
+    }
+}

--- a/milsim-platform/src/MilsimPlanning.Api/Services/RadioConflictDetectionService.cs
+++ b/milsim-platform/src/MilsimPlanning.Api/Services/RadioConflictDetectionService.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using MilsimPlanning.Api.Data;
+using MilsimPlanning.Api.Data.Entities;
+
+namespace MilsimPlanning.Api.Services;
+
+/// <summary>
+/// Detects exact-match frequency conflicts within the same channel (operation-scoped).
+/// AC-01/02/03: checks both primary and alternate frequencies, within the same operation only.
+/// </summary>
+public class RadioConflictDetectionService
+{
+    private readonly AppDbContext _db;
+
+    public RadioConflictDetectionService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    /// <summary>
+    /// Returns all existing assignments on the given channel that share the specified
+    /// frequency (primary or alternate), excluding the calling unit's own assignment.
+    /// </summary>
+    public async Task<List<ConflictInfo>> DetectConflictsAsync(
+        Guid channelId,
+        decimal frequency,
+        Guid? excludeAssignmentId = null)
+    {
+        var query = _db.RadioChannelAssignments
+            .Include(a => a.Squad)
+            .Include(a => a.Platoon)
+            .Include(a => a.Faction)
+            .Include(a => a.Channel)
+            .Where(a => a.ChannelId == channelId
+                     && (a.Primary == frequency || a.Alternate == frequency));
+
+        if (excludeAssignmentId.HasValue)
+            query = query.Where(a => a.Id != excludeAssignmentId.Value);
+
+        var matches = await query.ToListAsync();
+
+        return matches.Select(a =>
+        {
+            var (unitId, unitType, unitName) = ResolveUnit(a);
+            var conflictType = a.Primary == frequency ? "primary" : "alternate";
+            return new ConflictInfo(a.Id, unitId, unitType, unitName, frequency, conflictType);
+        }).ToList();
+    }
+
+    private static (Guid unitId, string unitType, string unitName) ResolveUnit(RadioChannelAssignment a)
+    {
+        if (a.SquadId.HasValue && a.Squad != null)
+            return (a.Squad.Id, "squad", a.Squad.Name);
+        if (a.PlatoonId.HasValue && a.Platoon != null)
+            return (a.Platoon.Id, "platoon", a.Platoon.Name);
+        if (a.FactionId.HasValue && a.Faction != null)
+            return (a.Faction.Id, "faction", a.Faction.Name);
+
+        // Fallback — should never happen in well-formed data
+        return (Guid.Empty, "unknown", "unknown");
+    }
+}
+
+public record ConflictInfo(
+    Guid AssignmentId,
+    Guid UnitId,
+    string UnitType,
+    string UnitName,
+    decimal Frequency,
+    string ConflictType   // "primary" | "alternate"
+);

--- a/web/src/__tests__/RadioChannelsPage.test.tsx
+++ b/web/src/__tests__/RadioChannelsPage.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { RadioChannelsPage } from '../pages/events/RadioChannelsPage';
+import type { RadioChannelListDto } from '../lib/api';
+
+// Mock auth so we can control commander vs. player role
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../hooks/useAuth';
+const mockUseAuth = vi.mocked(useAuth);
+
+const mockVhfChannel: RadioChannelListDto = {
+  id: 'chan-1',
+  name: 'Command Net',
+  callSign: null,
+  scope: 'VHF',
+  assignmentCount: 2,
+  conflictCount: 0,
+};
+
+const mockUhfChannel: RadioChannelListDto = {
+  id: 'chan-2',
+  name: 'Air Net',
+  callSign: null,
+  scope: 'UHF',
+  assignmentCount: 0,
+  conflictCount: 1,
+};
+
+function renderPage(role = 'faction_commander') {
+  mockUseAuth.mockReturnValue({
+    user: { id: 'user-1', role, email: 'test@test.com', callsign: 'TestUser' },
+    isAuthenticated: true,
+    login: vi.fn(),
+    logout: vi.fn(),
+  } as ReturnType<typeof useAuth>);
+
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/events/event-123/radio-channels']}>
+        <Routes>
+          <Route path="/events/:id/radio-channels" element={<RadioChannelsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('RadioChannelsPage', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/api/events/:eventId/radio-channels', () =>
+        HttpResponse.json([mockVhfChannel, mockUhfChannel])
+      )
+    );
+  });
+
+  // AC-06: channel list shows name and scope
+  it('renders channel list with name and scope badges', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Command Net')).toBeDefined();
+      expect(screen.getByText('Air Net')).toBeDefined();
+    });
+
+    // Scope badges present
+    expect(screen.getAllByText('VHF').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('UHF').length).toBeGreaterThan(0);
+  });
+
+  // AC-03: frequency range info displayed
+  it('shows frequency range info for each channel scope', async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Command Net')).toBeDefined());
+
+    expect(screen.getByText(/30\.0.87\.975 MHz/)).toBeDefined();
+    expect(screen.getByText(/225.400 MHz/)).toBeDefined();
+  });
+
+  // AC-02: channel creation form with name field
+  it('shows create form when New Channel clicked by commander', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('New Channel')).toBeDefined());
+    fireEvent.click(screen.getByText('New Channel'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Channel name')).toBeDefined();
+    });
+  });
+
+  // AC-04: VHF/UHF toggle visible in form
+  it('create form shows VHF and UHF radio options', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('New Channel')).toBeDefined());
+    fireEvent.click(screen.getByText('New Channel'));
+
+    await waitFor(() => {
+      // Radio buttons for VHF and UHF
+      const vhfOption = screen.getByDisplayValue('VHF');
+      const uhfOption = screen.getByDisplayValue('UHF');
+      expect(vhfOption).toBeDefined();
+      expect(uhfOption).toBeDefined();
+    });
+  });
+
+  // Players cannot create channels (commander-only UI)
+  it('does not show New Channel button for player role', async () => {
+    renderPage('player');
+
+    await waitFor(() => expect(screen.getByText('Command Net')).toBeDefined());
+
+    expect(screen.queryByText('New Channel')).toBeNull();
+  });
+
+  // AC-05: duplicate name shows error message
+  it('shows error message when channel name already exists', async () => {
+    server.use(
+      http.post('/api/events/:eventId/radio-channels', () =>
+        HttpResponse.json({ detail: 'Channel name already exists in this operation.' }, { status: 409 })
+      )
+    );
+
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('New Channel')).toBeDefined());
+    fireEvent.click(screen.getByText('New Channel'));
+
+    await waitFor(() => expect(screen.getByLabelText('Channel name')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Channel name'), { target: { value: 'Command Net' } });
+    fireEvent.click(screen.getByText('Save Channel'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Channel name already exists/)).toBeDefined();
+    });
+  });
+
+  // AC-07: edit button visible for commander
+  it('shows edit button for each channel when user is commander', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Command Net')).toBeDefined());
+
+    const editButtons = screen.getAllByRole('button', { name: /Edit channel/i });
+    expect(editButtons.length).toBe(2);
+  });
+
+  // AC-07: edit button not visible for player
+  it('does not show edit button for player role', async () => {
+    renderPage('player');
+
+    await waitFor(() => expect(screen.getByText('Command Net')).toBeDefined());
+
+    const editButtons = screen.queryAllByRole('button', { name: /Edit channel/i });
+    expect(editButtons.length).toBe(0);
+  });
+
+  // Conflict count displayed
+  it('displays conflict badge when conflictCount > 0', async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Air Net')).toBeDefined());
+
+    expect(screen.getByText(/1 conflict/)).toBeDefined();
+  });
+
+  // Empty state
+  it('shows empty state when no channels exist', async () => {
+    server.use(
+      http.get('/api/events/:eventId/radio-channels', () => HttpResponse.json([]))
+    );
+
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('No radio channels yet.')).toBeDefined();
+    });
+  });
+});

--- a/web/src/__tests__/RadioChannelsPage.test.tsx
+++ b/web/src/__tests__/RadioChannelsPage.test.tsx
@@ -444,4 +444,37 @@ describe('RadioChannelsPage', () => {
       ).toBe(true);
     });
   });
+
+  // AC-04: Frequency conflict error from backend (409) is shown in create form
+  it('Story 3 AC-04: shows conflict error when backend returns 409 on create', async () => {
+    server.use(
+      http.post('/api/events/:eventId/channel-assignments', () =>
+        HttpResponse.json(
+          { detail: "Frequency 36.500 MHz conflicts with primary frequency assigned to 'Alpha-1'." },
+          { status: 409 }
+        )
+      )
+    );
+
+    renderPage('faction_commander');
+
+    // Open the create form
+    await waitFor(() => expect(screen.getByRole('button', { name: /Assign Frequency/i })).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /Assign Frequency/i }));
+
+    // Fill in required fields
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+    fireEvent.change(screen.getByLabelText('Primary frequency (MHz)'), { target: { value: '36.500' } });
+    fireEvent.change(screen.getByLabelText('Select unit'), { target: { value: 'squad-1' } });
+
+    // Submit the form directly (avoids disabled-button timing issues)
+    const assignForm = document.querySelector('form.border') as HTMLFormElement;
+    fireEvent.submit(assignForm);
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.some((a) => /conflict/i.test(a.textContent ?? ''))).toBe(true);
+    });
+  });
 });

--- a/web/src/__tests__/RadioChannelsPage.test.tsx
+++ b/web/src/__tests__/RadioChannelsPage.test.tsx
@@ -41,6 +41,7 @@ const mockAssignment: ChannelAssignmentDto = {
   squadId: 'squad-1',
   squadName: 'Alpha-1',
   primaryFrequency: 36.5,
+  alternateFrequency: null,
   eventId: 'event-123',
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
@@ -343,6 +344,104 @@ describe('RadioChannelsPage', () => {
       // The validation error specifically matches the alert role
       const alerts = screen.getAllByRole('alert');
       expect(alerts.some((a) => /25 kHz/i.test(a.textContent ?? ''))).toBe(true);
+    });
+  });
+
+  // ── Story 3: Alternate Frequency ───────────────────────────────────────────
+
+  // Alternate frequency column header appears in table
+  it('Story 3: shows Alternate Frequency column in assignments table', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('Alternate Frequency')).toBeDefined();
+    });
+  });
+
+  // Null alternate frequency shows em dash
+  it('Story 3: shows em dash for null alternate frequency', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha-1')).toBeDefined();
+      // The dash for null alternate frequency
+      expect(screen.getByText('—')).toBeDefined();
+    });
+  });
+
+  // Alternate frequency displayed when present
+  it('Story 3: shows alternate frequency when present', async () => {
+    const assignmentWithAlt: ChannelAssignmentDto = {
+      ...mockAssignment,
+      id: 'assign-alt',
+      alternateFrequency: 36.525,
+    };
+
+    server.use(
+      http.get('/api/events/:eventId/channel-assignments', () =>
+        HttpResponse.json({ total: 1, items: [assignmentWithAlt] })
+      )
+    );
+
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('36.525 MHz')).toBeDefined();
+    });
+  });
+
+  // Alternate frequency input in create form
+  it('Story 3: Assign Frequency form shows alternate frequency input', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Alternate frequency (MHz)')).toBeDefined();
+    });
+  });
+
+  // Alternate frequency real-time validation: out of range
+  it('Story 3: shows validation error when alternate frequency is out of range', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Alternate frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Alternate frequency (MHz)'), { target: { value: '90.0' } });
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.some((a) => /out of range|within VHF/i.test(a.textContent ?? ''))).toBe(true);
+    });
+  });
+
+  // Alternate frequency real-time validation: same as primary
+  it('Story 3: shows error when alternate frequency matches primary', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Primary frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Primary frequency (MHz)'), { target: { value: '36.500' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Alternate frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Alternate frequency (MHz)'), { target: { value: '36.500' } });
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(
+        alerts.some((a) => /cannot match primary/i.test(a.textContent ?? ''))
+      ).toBe(true);
     });
   });
 });

--- a/web/src/__tests__/RadioChannelsPage.test.tsx
+++ b/web/src/__tests__/RadioChannelsPage.test.tsx
@@ -5,7 +5,7 @@ import { server } from '../mocks/server';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { RadioChannelsPage } from '../pages/events/RadioChannelsPage';
-import type { RadioChannelListDto } from '../lib/api';
+import type { RadioChannelListDto, ChannelAssignmentDto, ChannelAssignmentListDto } from '../lib/api';
 
 // Mock auth so we can control commander vs. player role
 vi.mock('../hooks/useAuth', () => ({
@@ -33,6 +33,40 @@ const mockUhfChannel: RadioChannelListDto = {
   conflictCount: 1,
 };
 
+const mockAssignment: ChannelAssignmentDto = {
+  id: 'assign-1',
+  radioChannelId: 'chan-1',
+  channelName: 'Command Net',
+  channelScope: 'VHF',
+  squadId: 'squad-1',
+  squadName: 'Alpha-1',
+  primaryFrequency: 36.5,
+  eventId: 'event-123',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const mockAssignmentList: ChannelAssignmentListDto = {
+  total: 1,
+  items: [mockAssignment],
+};
+
+const mockRoster = {
+  platoons: [
+    {
+      id: 'platoon-1',
+      name: 'Alpha Platoon',
+      isCommandElement: false,
+      hqPlayers: [],
+      squads: [
+        { id: 'squad-1', name: 'Alpha-1', players: [] },
+        { id: 'squad-2', name: 'Alpha-2', players: [] },
+      ],
+    },
+  ],
+  unassignedPlayers: [],
+};
+
 function renderPage(role = 'faction_commander') {
   mockUseAuth.mockReturnValue({
     user: { id: 'user-1', role, email: 'test@test.com', callsign: 'TestUser' },
@@ -58,6 +92,12 @@ describe('RadioChannelsPage', () => {
     server.use(
       http.get('/api/events/:eventId/radio-channels', () =>
         HttpResponse.json([mockVhfChannel, mockUhfChannel])
+      ),
+      http.get('/api/events/:eventId/channel-assignments', () =>
+        HttpResponse.json(mockAssignmentList)
+      ),
+      http.get('/api/events/:eventId/roster', () =>
+        HttpResponse.json(mockRoster)
       )
     );
   });
@@ -177,13 +217,132 @@ describe('RadioChannelsPage', () => {
   // Empty state
   it('shows empty state when no channels exist', async () => {
     server.use(
-      http.get('/api/events/:eventId/radio-channels', () => HttpResponse.json([]))
+      http.get('/api/events/:eventId/radio-channels', () => HttpResponse.json([])),
+      http.get('/api/events/:eventId/channel-assignments', () =>
+        HttpResponse.json({ total: 0, items: [] })
+      )
     );
 
     renderPage('faction_commander');
 
     await waitFor(() => {
       expect(screen.getByText('No radio channels yet.')).toBeDefined();
+    });
+  });
+
+  // ── Story 2: Assignment section ───────────────────────────────────────────
+
+  // AC-08: assignment list view per operation
+  it('AC-08: shows assignment list with squad name, channel, frequency', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha-1')).toBeDefined();
+      expect(screen.getByText('36.500 MHz')).toBeDefined();
+    });
+  });
+
+  // AC-09: edit and delete controls per assignment
+  it('AC-09: commander sees edit and delete buttons per assignment', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Alpha-1')).toBeDefined());
+
+    expect(screen.getByRole('button', { name: /Edit assignment for Alpha-1/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Delete assignment for Alpha-1/i })).toBeDefined();
+  });
+
+  // AC-09: player cannot edit/delete assignments
+  it('AC-09: player does not see edit/delete for assignments', async () => {
+    renderPage('player');
+
+    await waitFor(() => expect(screen.getByText('Alpha-1')).toBeDefined());
+
+    expect(screen.queryByRole('button', { name: /Edit assignment/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Delete assignment/i })).toBeNull();
+  });
+
+  // AC-01: unit selector in create form
+  it('AC-01: Assign Frequency form shows unit selector loaded from roster', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select unit')).toBeDefined();
+    });
+
+    // After roster loads, squads appear as options in the unit selector
+    await waitFor(() => {
+      const select = screen.getByLabelText('Select unit') as HTMLSelectElement;
+      const options = Array.from(select.options).map((o) => o.text);
+      expect(options.some((o) => o.includes('Alpha-1'))).toBe(true);
+    });
+  });
+
+  // AC-02: channel selector in create form
+  it('AC-02: Assign Frequency form shows channel selector', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Select channel')).toBeDefined();
+    });
+  });
+
+  // AC-03: frequency numeric input in create form
+  it('AC-03: Assign Frequency form shows primary frequency input', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Primary frequency (MHz)')).toBeDefined();
+    });
+  });
+
+  // AC-10: real-time inline validation on frequency input
+  it('AC-10: shows real-time validation error for out-of-range frequency', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+
+    // Select VHF channel
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+
+    // Enter out-of-range frequency
+    await waitFor(() => expect(screen.getByLabelText('Primary frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Primary frequency (MHz)'), { target: { value: '90.0' } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/out of range|within VHF/i)).toBeDefined();
+    });
+  });
+
+  // AC-10: real-time 25 kHz spacing validation
+  it('AC-10: shows validation error for invalid 25 kHz spacing', async () => {
+    renderPage('faction_commander');
+
+    await waitFor(() => expect(screen.getByText('Assign Frequency')).toBeDefined());
+    fireEvent.click(screen.getByText('Assign Frequency'));
+
+    await waitFor(() => expect(screen.getByLabelText('Select channel')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Select channel'), { target: { value: 'chan-1' } });
+
+    await waitFor(() => expect(screen.getByLabelText('Primary frequency (MHz)')).toBeDefined());
+    fireEvent.change(screen.getByLabelText('Primary frequency (MHz)'), { target: { value: '36.012' } });
+
+    await waitFor(() => {
+      // The validation error specifically matches the alert role
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.some((a) => /25 kHz/i.test(a.textContent ?? ''))).toBe(true);
     });
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,7 +21,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       return undefined as T;   // navigation is in flight; prevent further processing
     }
     const error = await response.json().catch(() => ({ error: response.statusText }));
-    throw Object.assign(new Error(error.error ?? 'API error'), { status: response.status });
+    throw Object.assign(new Error(error.detail ?? error.error ?? 'API error'), { status: response.status });
   }
   if (response.status === 204) return undefined as T;
   return response.json();
@@ -48,7 +48,7 @@ async function upload<T>(path: string, file: File, fieldName = 'file'): Promise<
       return undefined as T;
     }
     const error = await response.json().catch(() => ({ error: response.statusText }));
-    throw Object.assign(new Error(error.error ?? 'API error'), { status: response.status });
+    throw Object.assign(new Error(error.detail ?? error.error ?? 'API error'), { status: response.status });
   }
   if (response.status === 204) return undefined as T;
   return response.json();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -382,6 +382,7 @@ export interface ChannelAssignmentDto {
   squadId: string;
   squadName: string;
   primaryFrequency: number;
+  alternateFrequency: number | null;
   eventId: string;
   createdAt: string;
   updatedAt: string;
@@ -396,8 +397,10 @@ export interface CreateChannelAssignmentRequest {
   radioChannelId: string;
   squadId: string;
   primaryFrequency: number;
+  alternateFrequency?: number | null;
 }
 
 export interface UpdateChannelAssignmentRequest {
   primaryFrequency: number;
+  alternateFrequency?: number | null;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -168,6 +168,22 @@ export const api = {
       body: JSON.stringify(req),
     }),
 
+  // Channel assignment endpoints (Story 2)
+  getChannelAssignments: (eventId: string, limit = 50, offset = 0) =>
+    request<ChannelAssignmentListDto>(`/events/${eventId}/channel-assignments?limit=${limit}&offset=${offset}`),
+  createChannelAssignment: (eventId: string, req: CreateChannelAssignmentRequest) =>
+    request<ChannelAssignmentDto>(`/events/${eventId}/channel-assignments`, {
+      method: 'POST',
+      body: JSON.stringify(req),
+    }),
+  updateChannelAssignment: (eventId: string, id: string, req: UpdateChannelAssignmentRequest) =>
+    request<ChannelAssignmentDto>(`/events/${eventId}/channel-assignments/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(req),
+    }),
+  deleteChannelAssignment: (eventId: string, id: string) =>
+    request<void>(`/events/${eventId}/channel-assignments/${id}`, { method: 'DELETE' }),
+
   // Profile
   getProfile: () => request<UserProfile>('/profile'),
 };
@@ -354,4 +370,34 @@ export interface CreateRadioChannelRequest {
 export interface UpdateRadioChannelRequest {
   name: string;
   scope: ChannelScope;
+}
+
+// ─── Channel Assignment types (Story 2) ─────────────────────────────────────
+
+export interface ChannelAssignmentDto {
+  id: string;
+  radioChannelId: string;
+  channelName: string;
+  channelScope: string;
+  squadId: string;
+  squadName: string;
+  primaryFrequency: number;
+  eventId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChannelAssignmentListDto {
+  total: number;
+  items: ChannelAssignmentDto[];
+}
+
+export interface CreateChannelAssignmentRequest {
+  radioChannelId: string;
+  squadId: string;
+  primaryFrequency: number;
+}
+
+export interface UpdateChannelAssignmentRequest {
+  primaryFrequency: number;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -154,6 +154,20 @@ export const api = {
   setFactionFrequencies: (factionId: string, req: SetFrequenciesRequest) =>
     request<FrequencyLevelDto>(`/factions/${factionId}/frequencies`, { method: 'PUT', body: JSON.stringify(req) }),
 
+  // Radio channel endpoints (Story 1)
+  getRadioChannels: (eventId: string) =>
+    request<RadioChannelListDto[]>(`/events/${eventId}/radio-channels`),
+  createRadioChannel: (eventId: string, req: CreateRadioChannelRequest) =>
+    request<RadioChannelDetailDto>(`/events/${eventId}/radio-channels`, {
+      method: 'POST',
+      body: JSON.stringify(req),
+    }),
+  updateRadioChannel: (channelId: string, req: UpdateRadioChannelRequest) =>
+    request<RadioChannelDetailDto>(`/radio-channels/${channelId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(req),
+    }),
+
   // Profile
   getProfile: () => request<UserProfile>('/profile'),
 };
@@ -292,4 +306,52 @@ export interface EventFrequenciesDto {
 export interface SetFrequenciesRequest {
   primaryFrequency: string | null;
   backupFrequency: string | null;
+}
+
+// ─── Radio Channel types ────────────────────────────────────────────────────
+
+export type ChannelScope = 'VHF' | 'UHF';
+
+export interface RadioChannelListDto {
+  id: string;
+  name: string;
+  callSign: string | null;
+  scope: ChannelScope;
+  assignmentCount: number;
+  conflictCount: number;
+}
+
+export interface RadioChannelDetailDto {
+  id: string;
+  eventId: string;
+  name: string;
+  callSign: string | null;
+  scope: ChannelScope;
+  assignments: RadioChannelAssignmentDto[];
+  createdAt: string;
+}
+
+export interface RadioChannelAssignmentDto {
+  id: string;
+  channelId: string;
+  unitId: string;
+  unitType: string;
+  unitName: string;
+  primary: number | null;
+  alternate: number | null;
+  hasConflict: boolean;
+  conflictWith: string[] | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface CreateRadioChannelRequest {
+  name: string;
+  callSign?: string | null;
+  scope: ChannelScope;
+}
+
+export interface UpdateRadioChannelRequest {
+  name: string;
+  scope: ChannelScope;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -184,6 +184,10 @@ export const api = {
   deleteChannelAssignment: (eventId: string, id: string) =>
     request<void>(`/events/${eventId}/channel-assignments/${id}`, { method: 'DELETE' }),
 
+  // Conflict summary endpoint (Story 4 — AC-07)
+  getChannelAssignmentConflicts: (eventId: string) =>
+    request<ChannelAssignmentConflictSummaryDto>(`/events/${eventId}/channel-assignments/conflicts`),
+
   // Profile
   getProfile: () => request<UserProfile>('/profile'),
 };
@@ -372,7 +376,7 @@ export interface UpdateRadioChannelRequest {
   scope: ChannelScope;
 }
 
-// ─── Channel Assignment types (Story 2) ─────────────────────────────────────
+// ─── Channel Assignment types (Story 2 + Story 4) ───────────────────────────
 
 export interface ChannelAssignmentDto {
   id: string;
@@ -384,6 +388,8 @@ export interface ChannelAssignmentDto {
   primaryFrequency: number;
   alternateFrequency: number | null;
   eventId: string;
+  hasConflict: boolean;          // AC-05: conflict state flag
+  conflictWith: string[] | null; // AC-07: names of units this conflicts with
   createdAt: string;
   updatedAt: string;
 }
@@ -398,9 +404,28 @@ export interface CreateChannelAssignmentRequest {
   squadId: string;
   primaryFrequency: number;
   alternateFrequency?: number | null;
+  overrideConflict?: boolean;  // AC-04: advisory mode override flag
 }
 
 export interface UpdateChannelAssignmentRequest {
   primaryFrequency: number;
   alternateFrequency?: number | null;
+  overrideConflict?: boolean;  // AC-04: advisory mode override flag
+}
+
+// ─── Conflict summary types (Story 4 — AC-07) ───────────────────────────────
+
+export interface ChannelAssignmentConflictItemDto {
+  assignmentId: string;
+  squadName: string;
+  channelName: string;
+  conflictingFrequency: number;
+  frequencyType: string;          // "primary" | "alternate"
+  conflictingSquadName: string;
+}
+
+export interface ChannelAssignmentConflictSummaryDto {
+  eventId: string;
+  conflictCount: number;
+  conflicts: ChannelAssignmentConflictItemDto[];
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -22,6 +22,7 @@ import { NotificationBlastPage } from './pages/events/NotificationBlastPage';
 import { CsvImportPage } from './pages/roster/CsvImportPage';
 import { HierarchyBuilder } from './pages/roster/HierarchyBuilder';
 import { RosterView } from './pages/roster/RosterView';
+import { RadioChannelsPage } from './pages/events/RadioChannelsPage';
 import './index.css';
 
 const queryClient = new QueryClient();
@@ -56,6 +57,7 @@ const router = createBrowserRouter([
           { path: '/events/:id/maps', element: <MapResourcesPage /> },
           { path: '/events/:id/roster', element: <RosterView /> },
           { path: '/events/:id/notifications', element: <NotificationBlastPage /> },
+          { path: '/events/:id/radio-channels', element: <RadioChannelsPage /> },
 
           // Commander-only routes — redirect non-commanders to /dashboard
           {

--- a/web/src/pages/events/EventDetail.tsx
+++ b/web/src/pages/events/EventDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ChevronRight, Users, BookOpen, Map, AlertCircle, Calendar, MapPin, Eye } from 'lucide-react';
+import { ChevronRight, Users, BookOpen, Map, AlertCircle, Calendar, MapPin, Eye, Radio } from 'lucide-react';
 import { api } from '../../lib/api';
 import { useAuth } from '../../hooks/useAuth';
 import { Badge } from '../../components/ui/badge';
@@ -192,7 +192,7 @@ export function EventDetail() {
           </div>
 
           {/* ── Summary cards ───────────────────────────────────────────── */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
 
             {/* Players card */}
             <Link
@@ -273,6 +273,18 @@ export function EventDetail() {
                 </>
               )}
             </Link>
+
+            {/* Radio Channels card — AC-01: all users can navigate to channel list */}
+            <Link
+              to={`/events/${id}/radio-channels`}
+              className="block border rounded-lg p-4 hover:bg-muted/40 transition-colors space-y-2"
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Radio className="h-4 w-4 text-muted-foreground" />
+                Radio Channels
+              </div>
+              <p className="text-sm text-muted-foreground italic">View channels</p>
+            </Link>
           </div>
 
           {/* ── Commander controls ───────────────────────────────────────── */}
@@ -305,6 +317,12 @@ export function EventDetail() {
                 </Button>
                 <Button variant="outline" asChild>
                   <Link to={`/events/${id}/notifications`}>Notifications</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link to={`/events/${id}/radio-channels`}>
+                    <Radio className="h-4 w-4 mr-1.5" />
+                    Radio Channels
+                  </Link>
                 </Button>
                 <Button variant="outline" asChild>
                   <Link to={`/events/${id}/player`}>

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -1,0 +1,338 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Radio, Plus, Pencil, Check, X, AlertTriangle } from 'lucide-react';
+import { api, type RadioChannelListDto, type ChannelScope } from '../../lib/api';
+import { useAuth } from '../../hooks/useAuth';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Badge } from '../../components/ui/badge';
+import { toast } from 'sonner';
+
+// ── Frequency range constants (NATO standard) ─────────────────────────────────
+const SCOPE_INFO: Record<ChannelScope, { label: string; range: string }> = {
+  VHF: { label: 'VHF', range: '30.0–87.975 MHz' },
+  UHF: { label: 'UHF', range: '225–400 MHz' },
+};
+
+// ── Inline edit row ────────────────────────────────────────────────────────────
+
+interface ChannelRowProps {
+  channel: RadioChannelListDto;
+  isCommander: boolean;
+}
+
+function ChannelRow({ channel, isCommander }: ChannelRowProps) {
+  const queryClient = useQueryClient();
+  const { id: eventId } = useParams<{ id: string }>();
+
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState(channel.name);
+  const [editScope, setEditScope] = useState<ChannelScope>(channel.scope);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const updateMutation = useMutation({
+    mutationFn: () => api.updateRadioChannel(channel.id, { name: editName.trim(), scope: editScope }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['radio-channels', eventId] });
+      setEditing(false);
+      setEditError(null);
+      toast.success('Channel updated');
+    },
+    onError: (err: Error & { status?: number }) => {
+      if (err.status === 409) {
+        setEditError('Channel name already exists in this operation.');
+      } else {
+        setEditError(err.message);
+      }
+    },
+  });
+
+  const cancelEdit = () => {
+    setEditName(channel.name);
+    setEditScope(channel.scope);
+    setEditError(null);
+    setEditing(false);
+  };
+
+  const scopeInfo = SCOPE_INFO[channel.scope];
+
+  if (editing) {
+    return (
+      <tr className="border-b">
+        <td className="py-3 px-4">
+          <Input
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="h-8 w-full"
+            autoFocus
+            aria-label="Channel name"
+          />
+          {editError && <p className="text-xs text-red-600 mt-1">{editError}</p>}
+        </td>
+        <td className="py-3 px-4">
+          <select
+            value={editScope}
+            onChange={(e) => setEditScope(e.target.value as ChannelScope)}
+            className="h-8 rounded border border-input bg-background px-2 text-sm"
+            aria-label="Channel scope"
+          >
+            <option value="VHF">VHF (30.0–87.975 MHz)</option>
+            <option value="UHF">UHF (225–400 MHz)</option>
+          </select>
+        </td>
+        <td className="py-3 px-4 text-sm text-muted-foreground">{channel.assignmentCount}</td>
+        <td className="py-3 px-4">
+          {channel.conflictCount > 0 && (
+            <Badge variant="destructive" className="text-xs">
+              {channel.conflictCount} conflict{channel.conflictCount !== 1 ? 's' : ''}
+            </Badge>
+          )}
+        </td>
+        <td className="py-3 px-4">
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => updateMutation.mutate()}
+              disabled={updateMutation.isPending || !editName.trim()}
+              aria-label="Save changes"
+            >
+              <Check className="h-4 w-4 text-green-600" />
+            </Button>
+            <Button size="sm" variant="ghost" onClick={cancelEdit} aria-label="Cancel edit">
+              <X className="h-4 w-4 text-red-600" />
+            </Button>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr className="border-b hover:bg-muted/50">
+      <td className="py-3 px-4 font-medium">{channel.name}</td>
+      <td className="py-3 px-4">
+        <Badge variant={channel.scope === 'VHF' ? 'default' : 'secondary'}>
+          {channel.scope}
+        </Badge>
+        <span className="ml-2 text-xs text-muted-foreground">{scopeInfo.range}</span>
+      </td>
+      <td className="py-3 px-4 text-sm text-muted-foreground">{channel.assignmentCount}</td>
+      <td className="py-3 px-4">
+        {channel.conflictCount > 0 && (
+          <Badge variant="destructive" className="text-xs">
+            <AlertTriangle className="h-3 w-3 mr-1" />
+            {channel.conflictCount} conflict{channel.conflictCount !== 1 ? 's' : ''}
+          </Badge>
+        )}
+      </td>
+      <td className="py-3 px-4">
+        {isCommander && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setEditing(true)}
+            aria-label={`Edit channel ${channel.name}`}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ── Create form ────────────────────────────────────────────────────────────────
+
+interface CreateChannelFormProps {
+  eventId: string;
+}
+
+function CreateChannelForm({ eventId }: CreateChannelFormProps) {
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState('');
+  const [scope, setScope] = useState<ChannelScope>('VHF');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const createMutation = useMutation({
+    mutationFn: () => api.createRadioChannel(eventId, { name: name.trim(), scope }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['radio-channels', eventId] });
+      setName('');
+      setScope('VHF');
+      setFormError(null);
+      setOpen(false);
+      toast.success('Channel created');
+    },
+    onError: (err: Error & { status?: number }) => {
+      if (err.status === 409) {
+        setFormError('Channel name already exists in this operation.');
+      } else {
+        setFormError(err.message);
+      }
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setFormError('Channel name is required.');
+      return;
+    }
+    setFormError(null);
+    createMutation.mutate();
+  };
+
+  if (!open) {
+    return (
+      <Button onClick={() => setOpen(true)} size="sm">
+        <Plus className="h-4 w-4 mr-1" />
+        New Channel
+      </Button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border rounded-lg p-4 bg-muted/30 space-y-4">
+      <h3 className="font-semibold text-sm">Create Radio Channel</h3>
+
+      {/* Frequency range reference */}
+      <div className="rounded-md bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 p-3 text-sm">
+        <p className="font-medium text-blue-800 dark:text-blue-300 mb-1">NATO Frequency Ranges</p>
+        <ul className="text-blue-700 dark:text-blue-400 space-y-0.5">
+          <li><span className="font-medium">VHF:</span> 30.0–87.975 MHz (25 kHz spacing)</li>
+          <li><span className="font-medium">UHF:</span> 225–400 MHz (25 kHz spacing)</li>
+        </ul>
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="channel-name" className="text-sm font-medium">
+          Channel name <span className="text-red-500">*</span>
+        </label>
+        <Input
+          id="channel-name"
+          aria-label="Channel name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Command Net, Air Net"
+          className="max-w-sm"
+          autoFocus
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="channel-scope" className="text-sm font-medium">
+          Scope
+        </label>
+        <div className="flex gap-4">
+          {(['VHF', 'UHF'] as ChannelScope[]).map((s) => (
+            <label key={s} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value={s}
+                checked={scope === s}
+                onChange={() => setScope(s)}
+                className="accent-primary"
+              />
+              <span className="text-sm font-medium">{s}</span>
+              <span className="text-xs text-muted-foreground">{SCOPE_INFO[s].range}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {formError && (
+        <p className="text-sm text-red-600" role="alert">{formError}</p>
+      )}
+
+      <div className="flex gap-2">
+        <Button type="submit" size="sm" disabled={createMutation.isPending || !name.trim()}>
+          {createMutation.isPending ? 'Saving…' : 'Save Channel'}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => { setOpen(false); setName(''); setFormError(null); }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// ── Page component ─────────────────────────────────────────────────────────────
+
+export function RadioChannelsPage() {
+  const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
+  const isCommander = user?.role === 'faction_commander';
+
+  const { data: channels, isLoading, error } = useQuery({
+    queryKey: ['radio-channels', id],
+    queryFn: () => api.getRadioChannels(id!),
+    enabled: !!id,
+  });
+
+  if (isLoading) return <div className="p-6">Loading channels…</div>;
+  if (error) return <div className="p-6 text-red-600">Failed to load channels.</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Breadcrumb */}
+      <nav className="text-sm text-muted-foreground flex items-center gap-1">
+        <Link to="/events" className="hover:underline">Events</Link>
+        <span>/</span>
+        <Link to={`/events/${id}`} className="hover:underline">Event</Link>
+        <span>/</span>
+        <span className="text-foreground font-medium">Radio Channels</span>
+      </nav>
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Radio className="h-5 w-5 text-primary" />
+          <h1 className="text-xl font-semibold">Radio Channels</h1>
+        </div>
+        {isCommander && <CreateChannelForm eventId={id!} />}
+      </div>
+
+      {/* Channel list */}
+      {channels && channels.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          <Radio className="h-8 w-8 mx-auto mb-2 opacity-40" />
+          <p>No radio channels yet.</p>
+          {isCommander && <p className="text-sm mt-1">Click "New Channel" to get started.</p>}
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="text-left py-2 px-4 font-medium">Channel Name</th>
+                <th className="text-left py-2 px-4 font-medium">Scope / Range</th>
+                <th className="text-left py-2 px-4 font-medium">Assignments</th>
+                <th className="text-left py-2 px-4 font-medium">Conflicts</th>
+                <th className="py-2 px-4" />
+              </tr>
+            </thead>
+            <tbody>
+              {channels?.map((channel) => (
+                <ChannelRow
+                  key={channel.id}
+                  channel={channel}
+                  isCommander={isCommander}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -12,6 +12,14 @@ import { useAuth } from '../../hooks/useAuth';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Badge } from '../../components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '../../components/ui/dialog';
 import { toast } from 'sonner';
 
 // ── Frequency range constants (NATO standard) ─────────────────────────────────
@@ -19,6 +27,39 @@ const SCOPE_INFO: Record<ChannelScope, { label: string; range: string; min: numb
   VHF: { label: 'VHF', range: '30.0–87.975 MHz', min: 30.0, max: 87.975 },
   UHF: { label: 'UHF', range: '225–400 MHz', min: 225.0, max: 400.0 },
 };
+
+// ── AC-04: Advisory conflict confirmation dialog ───────────────────────────────
+
+interface ConflictConfirmDialogProps {
+  open: boolean;
+  conflictMessage: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConflictConfirmDialog({ open, conflictMessage, onConfirm, onCancel }: ConflictConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-yellow-500" />
+            Frequency Conflict Detected
+          </DialogTitle>
+          <DialogDescription>
+            {conflictMessage} Proceeding will create a conflict. Are you sure you want to continue?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          <Button variant="destructive" onClick={onConfirm} aria-label="Proceed with conflict">
+            OK, Proceed Anyway
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 // ── Real-time frequency validation (AC-10) ────────────────────────────────────
 
@@ -306,13 +347,16 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
   );
   const [altFreqError, setAltFreqError] = useState<string | null>(null);
 
+  // AC-04: Advisory mode conflict dialog state
+  const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
+  const [conflictMessage, setConflictMessage] = useState('');
+
   const scope = (assignment.channelScope as ChannelScope) ?? 'VHF';
 
   // Real-time validation as user types (AC-10)
   const handleFreqChange = (val: string) => {
     setFreqValue(val);
     setFreqError(validateFrequency(val, scope));
-    // Re-validate alternate against new primary if alternate is present
     if (altFreqValue) {
       const altErr = validateFrequency(altFreqValue, scope);
       if (altErr) {
@@ -341,20 +385,26 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
     }
   };
 
+  // AC-04: mutation accepts override flag to support advisory re-submit
   const updateMutation = useMutation({
-    mutationFn: () =>
+    mutationFn: (overrideConflict = false) =>
       api.updateChannelAssignment(eventId, assignment.id, {
         primaryFrequency: parseFloat(freqValue),
         alternateFrequency: altFreqValue ? parseFloat(altFreqValue) : null,
+        overrideConflict,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
+      void queryClient.invalidateQueries({ queryKey: ['channel-assignment-conflicts', eventId] });
       setEditing(false);
+      setConflictDialogOpen(false);
       toast.success('Assignment updated');
     },
     onError: (err: Error & { status?: number }) => {
       if (err.status === 409) {
-        setFreqError(`Frequency conflict: ${err.message}`);
+        // AC-04: Show advisory dialog instead of static error
+        setConflictMessage(err.message);
+        setConflictDialogOpen(true);
       } else {
         setFreqError(err.message);
       }
@@ -366,6 +416,7 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
       void queryClient.invalidateQueries({ queryKey: ['radio-channels', eventId] });
+      void queryClient.invalidateQueries({ queryKey: ['channel-assignment-conflicts', eventId] });
       toast.success('Assignment deleted');
     },
     onError: (err: Error) => {
@@ -385,6 +436,7 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
         : ''
     );
     setAltFreqError(null);
+    setConflictDialogOpen(false);
   };
 
   const isSaveDisabled =
@@ -392,74 +444,94 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
 
   if (editing) {
     return (
-      <tr className="border-b">
-        <td className="py-3 px-4 text-sm">{assignment.squadName}</td>
-        <td className="py-3 px-4 text-sm">{assignment.channelName}</td>
-        <td className="py-3 px-4">
-          <div className="space-y-1">
-            <Input
-              aria-label="Primary frequency (MHz)"
-              value={freqValue}
-              onChange={(e) => handleFreqChange(e.target.value)}
-              placeholder="e.g. 36.500"
-              className="h-8 w-32"
-              type="number"
-              step="0.025"
-              min={channel ? SCOPE_INFO[channel.scope].min : 30}
-              max={channel ? SCOPE_INFO[channel.scope].max : 400}
-              autoFocus
-            />
-            {freqError && (
-              <p className="text-xs text-red-600" role="alert">{freqError}</p>
-            )}
-          </div>
-        </td>
-        <td className="py-3 px-4">
-          <div className="space-y-1">
-            <Input
-              aria-label="Alternate frequency (MHz)"
-              value={altFreqValue}
-              onChange={(e) => handleAltFreqChange(e.target.value)}
-              placeholder="Optional"
-              className="h-8 w-32"
-              type="number"
-              step="0.025"
-              min={channel ? SCOPE_INFO[channel.scope].min : 30}
-              max={channel ? SCOPE_INFO[channel.scope].max : 400}
-            />
-            {altFreqError && (
-              <p className="text-xs text-red-600" role="alert">{altFreqError}</p>
-            )}
-          </div>
-        </td>
-        <td className="py-3 px-4">
-          <div className="flex gap-1">
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => updateMutation.mutate()}
-              disabled={isSaveDisabled}
-              aria-label="Save assignment"
-            >
-              <Check className="h-4 w-4 text-green-600" />
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={cancelEdit}
-              aria-label="Cancel edit"
-            >
-              <X className="h-4 w-4 text-red-600" />
-            </Button>
-          </div>
-        </td>
-      </tr>
+      <>
+        <tr className="border-b">
+          <td className="py-3 px-4 text-sm">{assignment.squadName}</td>
+          <td className="py-3 px-4 text-sm">{assignment.channelName}</td>
+          <td className="py-3 px-4">
+            <div className="space-y-1">
+              <Input
+                aria-label="Primary frequency (MHz)"
+                value={freqValue}
+                onChange={(e) => handleFreqChange(e.target.value)}
+                placeholder="e.g. 36.500"
+                className="h-8 w-32"
+                type="number"
+                step="0.025"
+                min={channel ? SCOPE_INFO[channel.scope].min : 30}
+                max={channel ? SCOPE_INFO[channel.scope].max : 400}
+                autoFocus
+              />
+              {freqError && (
+                <p className="text-xs text-red-600" role="alert">{freqError}</p>
+              )}
+            </div>
+          </td>
+          <td className="py-3 px-4">
+            <div className="space-y-1">
+              <Input
+                aria-label="Alternate frequency (MHz)"
+                value={altFreqValue}
+                onChange={(e) => handleAltFreqChange(e.target.value)}
+                placeholder="Optional"
+                className="h-8 w-32"
+                type="number"
+                step="0.025"
+                min={channel ? SCOPE_INFO[channel.scope].min : 30}
+                max={channel ? SCOPE_INFO[channel.scope].max : 400}
+              />
+              {altFreqError && (
+                <p className="text-xs text-red-600" role="alert">{altFreqError}</p>
+              )}
+            </div>
+          </td>
+          <td className="py-3 px-4">
+            <div className="flex gap-1">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => updateMutation.mutate(false)}
+                disabled={isSaveDisabled}
+                aria-label="Save assignment"
+              >
+                <Check className="h-4 w-4 text-green-600" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={cancelEdit}
+                aria-label="Cancel edit"
+              >
+                <X className="h-4 w-4 text-red-600" />
+              </Button>
+            </div>
+          </td>
+        </tr>
+        {/* AC-04: Advisory conflict dialog */}
+        <ConflictConfirmDialog
+          open={conflictDialogOpen}
+          conflictMessage={conflictMessage}
+          onConfirm={() => updateMutation.mutate(true)}
+          onCancel={() => setConflictDialogOpen(false)}
+        />
+      </>
     );
   }
 
   return (
     <tr className="border-b hover:bg-muted/50">
-      <td className="py-3 px-4 text-sm font-medium">{assignment.squadName}</td>
+      <td className="py-3 px-4 text-sm font-medium">
+        <div className="flex items-center gap-2">
+          {assignment.squadName}
+          {/* AC-05: Show conflict badge when assignment has active conflict */}
+          {assignment.hasConflict && (
+            <Badge variant="destructive" className="text-xs" aria-label="Frequency conflict">
+              <AlertTriangle className="h-3 w-3 mr-1" />
+              Conflict
+            </Badge>
+          )}
+        </div>
+      </td>
       <td className="py-3 px-4 text-sm">
         {assignment.channelName}
         <span className="ml-2 text-xs text-muted-foreground">{assignment.channelScope}</span>
@@ -520,6 +592,10 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
   const [freqError, setFreqError] = useState<string | null>(null);
   const [altFreqValue, setAltFreqValue] = useState('');
   const [altFreqError, setAltFreqError] = useState<string | null>(null);
+
+  // AC-04: Advisory mode conflict dialog state
+  const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
+  const [conflictMessage, setConflictMessage] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
 
   // Load roster to get squad list (AC-01)
@@ -596,17 +672,20 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     }
   };
 
+  // AC-04: mutation accepts override flag to support advisory re-submit
   const createMutation = useMutation({
-    mutationFn: () =>
+    mutationFn: (overrideConflict = false) =>
       api.createChannelAssignment(eventId, {
         radioChannelId: channelId,
         squadId,
         primaryFrequency: parseFloat(freqValue),
         alternateFrequency: altFreqValue ? parseFloat(altFreqValue) : null,
+        overrideConflict,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
       void queryClient.invalidateQueries({ queryKey: ['radio-channels', eventId] });
+      void queryClient.invalidateQueries({ queryKey: ['channel-assignment-conflicts', eventId] });
       setOpen(false);
       setChannelId('');
       setSquadId('');
@@ -615,11 +694,14 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
       setAltFreqValue('');
       setAltFreqError(null);
       setFormError(null);
+      setConflictDialogOpen(false);
       toast.success('Assignment created');
     },
     onError: (err: Error & { status?: number }) => {
       if (err.status === 409) {
-        setFormError(`Frequency conflict: ${err.message}`);
+        // AC-04: Show advisory dialog instead of static error
+        setConflictMessage(err.message);
+        setConflictDialogOpen(true);
       } else {
         setFormError(err.message);
       }
@@ -634,7 +716,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     if (err) { setFreqError(err); return; }
     if (altFreqError) return;
     setFormError(null);
-    createMutation.mutate();
+    createMutation.mutate(false);
   };
 
   if (!open) {
@@ -782,11 +864,20 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
             setAltFreqValue('');
             setAltFreqError(null);
             setFormError(null);
+            setConflictDialogOpen(false);
           }}
         >
           Cancel
         </Button>
       </div>
+
+      {/* AC-04: Advisory conflict dialog */}
+      <ConflictConfirmDialog
+        open={conflictDialogOpen}
+        conflictMessage={conflictMessage}
+        onConfirm={() => createMutation.mutate(true)}
+        onCancel={() => setConflictDialogOpen(false)}
+      />
     </form>
   );
 }
@@ -853,6 +944,46 @@ function AssignmentsSection({ eventId, channels, isCommander }: AssignmentsSecti
           </table>
         </div>
       )}
+
+      {/* AC-07: Conflict summary panel */}
+      <ConflictSummarySection eventId={eventId} />
+    </div>
+  );
+}
+
+// ── AC-07: Conflict summary section ──────────────────────────────────────────
+
+interface ConflictSummarySectionProps {
+  eventId: string;
+}
+
+function ConflictSummarySection({ eventId }: ConflictSummarySectionProps) {
+  const { data } = useQuery({
+    queryKey: ['channel-assignment-conflicts', eventId],
+    queryFn: () => api.getChannelAssignmentConflicts(eventId),
+    enabled: !!eventId,
+  });
+
+  if (!data || data.conflictCount === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-4 space-y-2">
+      <div className="flex items-center gap-2 text-destructive font-semibold text-sm">
+        <AlertTriangle className="h-4 w-4" />
+        {data.conflictCount} Frequency Conflict{data.conflictCount !== 1 ? 's' : ''}
+      </div>
+      <ul className="text-sm space-y-1">
+        {data.conflicts.map((c, i) => (
+          <li key={i} className="text-muted-foreground">
+            <span className="font-medium text-foreground">{c.squadName}</span>
+            {' '}({c.frequencyType}:{' '}
+            <span className="font-mono">{c.conflictingFrequency.toFixed(3)} MHz</span>)
+            {' '}conflicts with{' '}
+            <span className="font-medium text-foreground">{c.conflictingSquadName}</span>
+            {' '}on <span className="font-medium">{c.channelName}</span>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -299,18 +299,53 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
   const [editing, setEditing] = useState(false);
   const [freqValue, setFreqValue] = useState(assignment.primaryFrequency.toString());
   const [freqError, setFreqError] = useState<string | null>(null);
+  const [altFreqValue, setAltFreqValue] = useState(
+    assignment.alternateFrequency !== null && assignment.alternateFrequency !== undefined
+      ? assignment.alternateFrequency.toString()
+      : ''
+  );
+  const [altFreqError, setAltFreqError] = useState<string | null>(null);
+
+  const scope = (assignment.channelScope as ChannelScope) ?? 'VHF';
 
   // Real-time validation as user types (AC-10)
   const handleFreqChange = (val: string) => {
     setFreqValue(val);
-    const scope = (assignment.channelScope as ChannelScope) ?? 'VHF';
     setFreqError(validateFrequency(val, scope));
+    // Re-validate alternate against new primary if alternate is present
+    if (altFreqValue) {
+      const altErr = validateFrequency(altFreqValue, scope);
+      if (altErr) {
+        setAltFreqError(altErr);
+      } else if (parseFloat(altFreqValue) === parseFloat(val)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
+  };
+
+  const handleAltFreqChange = (val: string) => {
+    setAltFreqValue(val);
+    if (!val) {
+      setAltFreqError(null);
+      return;
+    }
+    const err = validateFrequency(val, scope);
+    if (err) {
+      setAltFreqError(err);
+    } else if (parseFloat(val) === parseFloat(freqValue)) {
+      setAltFreqError('Alternate frequency cannot match primary frequency');
+    } else {
+      setAltFreqError(null);
+    }
   };
 
   const updateMutation = useMutation({
     mutationFn: () =>
       api.updateChannelAssignment(eventId, assignment.id, {
         primaryFrequency: parseFloat(freqValue),
+        alternateFrequency: altFreqValue ? parseFloat(altFreqValue) : null,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
@@ -335,6 +370,21 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
   });
 
   const channel = channels.find((c) => c.id === assignment.radioChannelId);
+
+  const cancelEdit = () => {
+    setEditing(false);
+    setFreqValue(assignment.primaryFrequency.toString());
+    setFreqError(null);
+    setAltFreqValue(
+      assignment.alternateFrequency !== null && assignment.alternateFrequency !== undefined
+        ? assignment.alternateFrequency.toString()
+        : ''
+    );
+    setAltFreqError(null);
+  };
+
+  const isSaveDisabled =
+    updateMutation.isPending || !!freqError || !freqValue || !!altFreqError;
 
   if (editing) {
     return (
@@ -361,12 +411,30 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
           </div>
         </td>
         <td className="py-3 px-4">
+          <div className="space-y-1">
+            <Input
+              aria-label="Alternate frequency (MHz)"
+              value={altFreqValue}
+              onChange={(e) => handleAltFreqChange(e.target.value)}
+              placeholder="Optional"
+              className="h-8 w-32"
+              type="number"
+              step="0.025"
+              min={channel ? SCOPE_INFO[channel.scope].min : 30}
+              max={channel ? SCOPE_INFO[channel.scope].max : 400}
+            />
+            {altFreqError && (
+              <p className="text-xs text-red-600" role="alert">{altFreqError}</p>
+            )}
+          </div>
+        </td>
+        <td className="py-3 px-4">
           <div className="flex gap-1">
             <Button
               size="sm"
               variant="ghost"
               onClick={() => updateMutation.mutate()}
-              disabled={updateMutation.isPending || !!freqError || !freqValue}
+              disabled={isSaveDisabled}
               aria-label="Save assignment"
             >
               <Check className="h-4 w-4 text-green-600" />
@@ -374,7 +442,7 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
             <Button
               size="sm"
               variant="ghost"
-              onClick={() => { setEditing(false); setFreqValue(assignment.primaryFrequency.toString()); setFreqError(null); }}
+              onClick={cancelEdit}
               aria-label="Cancel edit"
             >
               <X className="h-4 w-4 text-red-600" />
@@ -393,6 +461,11 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
         <span className="ml-2 text-xs text-muted-foreground">{assignment.channelScope}</span>
       </td>
       <td className="py-3 px-4 text-sm font-mono">{assignment.primaryFrequency.toFixed(3)} MHz</td>
+      <td className="py-3 px-4 text-sm font-mono">
+        {assignment.alternateFrequency !== null && assignment.alternateFrequency !== undefined
+          ? `${assignment.alternateFrequency.toFixed(3)} MHz`
+          : '—'}
+      </td>
       <td className="py-3 px-4">
         {isCommander && (
           <div className="flex gap-1">
@@ -441,6 +514,8 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
   const [squadId, setSquadId] = useState('');
   const [freqValue, setFreqValue] = useState('');
   const [freqError, setFreqError] = useState<string | null>(null);
+  const [altFreqValue, setAltFreqValue] = useState('');
+  const [altFreqError, setAltFreqError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
   // Load roster to get squad list (AC-01)
@@ -467,6 +542,35 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     } else {
       setFreqError(null);
     }
+    // Re-validate alternate against new primary
+    if (altFreqValue && selectedChannel) {
+      const altErr = validateFrequency(altFreqValue, selectedChannel.scope);
+      if (altErr) {
+        setAltFreqError(altErr);
+      } else if (parseFloat(altFreqValue) === parseFloat(val)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
+  };
+
+  const handleAltFreqChange = (val: string) => {
+    setAltFreqValue(val);
+    if (!val) {
+      setAltFreqError(null);
+      return;
+    }
+    if (selectedChannel) {
+      const err = validateFrequency(val, selectedChannel.scope);
+      if (err) {
+        setAltFreqError(err);
+      } else if (parseFloat(val) === parseFloat(freqValue)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
   };
 
   // Re-validate when channel scope changes
@@ -476,6 +580,16 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     if (ch && freqValue) {
       setFreqError(validateFrequency(freqValue, ch.scope));
     }
+    if (ch && altFreqValue) {
+      const altErr = validateFrequency(altFreqValue, ch.scope);
+      if (altErr) {
+        setAltFreqError(altErr);
+      } else if (freqValue && parseFloat(altFreqValue) === parseFloat(freqValue)) {
+        setAltFreqError('Alternate frequency cannot match primary frequency');
+      } else {
+        setAltFreqError(null);
+      }
+    }
   };
 
   const createMutation = useMutation({
@@ -484,6 +598,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
         radioChannelId: channelId,
         squadId,
         primaryFrequency: parseFloat(freqValue),
+        alternateFrequency: altFreqValue ? parseFloat(altFreqValue) : null,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
@@ -493,6 +608,8 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
       setSquadId('');
       setFreqValue('');
       setFreqError(null);
+      setAltFreqValue('');
+      setAltFreqError(null);
       setFormError(null);
       toast.success('Assignment created');
     },
@@ -507,6 +624,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
     if (!squadId) { setFormError('Select a unit.'); return; }
     const err = selectedChannel ? validateFrequency(freqValue, selectedChannel.scope) : 'Select a channel first.';
     if (err) { setFreqError(err); return; }
+    if (altFreqError) return;
     setFormError(null);
     createMutation.mutate();
   };
@@ -601,6 +719,36 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
         )}
       </div>
 
+      {/* Alternate frequency input (Story 3) */}
+      <div className="space-y-2">
+        <label htmlFor="assign-alt-freq" className="text-sm font-medium">
+          Alternate frequency (MHz) <span className="text-muted-foreground text-xs">(optional)</span>
+        </label>
+        <Input
+          id="assign-alt-freq"
+          aria-label="Alternate frequency (MHz)"
+          value={altFreqValue}
+          onChange={(e) => handleAltFreqChange(e.target.value)}
+          placeholder={
+            selectedChannel
+              ? `e.g. ${selectedChannel.scope === 'VHF' ? '36.525' : '225.050'}`
+              : 'Select a channel first'
+          }
+          type="number"
+          step="0.025"
+          min={selectedChannel ? SCOPE_INFO[selectedChannel.scope].min : undefined}
+          max={selectedChannel ? SCOPE_INFO[selectedChannel.scope].max : undefined}
+          className="max-w-xs"
+          disabled={!channelId}
+        />
+        {altFreqError && (
+          <p className="text-xs text-red-600" role="alert">{altFreqError}</p>
+        )}
+        {selectedChannel && !altFreqError && altFreqValue && (
+          <p className="text-xs text-green-600">Valid {selectedChannel.scope} alternate frequency</p>
+        )}
+      </div>
+
       {formError && (
         <p className="text-sm text-red-600" role="alert">{formError}</p>
       )}
@@ -609,7 +757,7 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
         <Button
           type="submit"
           size="sm"
-          disabled={createMutation.isPending || !channelId || !squadId || !!freqError || !freqValue}
+          disabled={createMutation.isPending || !channelId || !squadId || !!freqError || !freqValue || !!altFreqError}
         >
           {createMutation.isPending ? 'Saving…' : 'Save Assignment'}
         </Button>
@@ -623,6 +771,8 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
             setSquadId('');
             setFreqValue('');
             setFreqError(null);
+            setAltFreqValue('');
+            setAltFreqError(null);
             setFormError(null);
           }}
         >
@@ -677,6 +827,7 @@ function AssignmentsSection({ eventId, channels, isCommander }: AssignmentsSecti
                 <th className="text-left py-2 px-4 font-medium">Unit</th>
                 <th className="text-left py-2 px-4 font-medium">Channel</th>
                 <th className="text-left py-2 px-4 font-medium">Primary Frequency</th>
+                <th className="text-left py-2 px-4 font-medium">Alternate Frequency</th>
                 <th className="py-2 px-4" />
               </tr>
             </thead>

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -1,8 +1,13 @@
 import { useState } from 'react';
 import { useParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Radio, Plus, Pencil, Check, X, AlertTriangle } from 'lucide-react';
-import { api, type RadioChannelListDto, type ChannelScope } from '../../lib/api';
+import { Radio, Plus, Pencil, Check, X, AlertTriangle, Trash2 } from 'lucide-react';
+import {
+  api,
+  type RadioChannelListDto,
+  type ChannelScope,
+  type ChannelAssignmentDto,
+} from '../../lib/api';
 import { useAuth } from '../../hooks/useAuth';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
@@ -10,10 +15,23 @@ import { Badge } from '../../components/ui/badge';
 import { toast } from 'sonner';
 
 // ── Frequency range constants (NATO standard) ─────────────────────────────────
-const SCOPE_INFO: Record<ChannelScope, { label: string; range: string }> = {
-  VHF: { label: 'VHF', range: '30.0–87.975 MHz' },
-  UHF: { label: 'UHF', range: '225–400 MHz' },
+const SCOPE_INFO: Record<ChannelScope, { label: string; range: string; min: number; max: number }> = {
+  VHF: { label: 'VHF', range: '30.0–87.975 MHz', min: 30.0, max: 87.975 },
+  UHF: { label: 'UHF', range: '225–400 MHz', min: 225.0, max: 400.0 },
 };
+
+// ── Real-time frequency validation (AC-10) ────────────────────────────────────
+
+function validateFrequency(value: string, scope: ChannelScope): string | null {
+  const num = parseFloat(value);
+  if (isNaN(num)) return 'Enter a valid frequency in MHz (e.g., 36.500).';
+  const { min, max, range } = SCOPE_INFO[scope];
+  if (num < min || num > max) return `Frequency must be within ${scope} range: ${range}.`;
+  // 25 kHz spacing: (freq * 1000) % 25 === 0
+  if (Math.round(num * 1000) % 25 !== 0)
+    return 'Frequency must align to 25 kHz spacing (e.g., 36.500, 36.525).';
+  return null;
+}
 
 // ── Inline edit row ────────────────────────────────────────────────────────────
 
@@ -143,7 +161,7 @@ function ChannelRow({ channel, isCommander }: ChannelRowProps) {
   );
 }
 
-// ── Create form ────────────────────────────────────────────────────────────────
+// ── Create channel form ────────────────────────────────────────────────────────
 
 interface CreateChannelFormProps {
   eventId: string;
@@ -266,6 +284,420 @@ function CreateChannelForm({ eventId }: CreateChannelFormProps) {
   );
 }
 
+// ── Assignment row (AC-09: edit/delete controls) ──────────────────────────────
+
+interface AssignmentRowProps {
+  assignment: ChannelAssignmentDto;
+  channels: RadioChannelListDto[];
+  isCommander: boolean;
+  eventId: string;
+}
+
+function AssignmentRow({ assignment, channels, isCommander, eventId }: AssignmentRowProps) {
+  const queryClient = useQueryClient();
+
+  const [editing, setEditing] = useState(false);
+  const [freqValue, setFreqValue] = useState(assignment.primaryFrequency.toString());
+  const [freqError, setFreqError] = useState<string | null>(null);
+
+  // Real-time validation as user types (AC-10)
+  const handleFreqChange = (val: string) => {
+    setFreqValue(val);
+    const scope = (assignment.channelScope as ChannelScope) ?? 'VHF';
+    setFreqError(validateFrequency(val, scope));
+  };
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      api.updateChannelAssignment(eventId, assignment.id, {
+        primaryFrequency: parseFloat(freqValue),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
+      setEditing(false);
+      toast.success('Assignment updated');
+    },
+    onError: (err: Error & { status?: number }) => {
+      setFreqError(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => api.deleteChannelAssignment(eventId, assignment.id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
+      void queryClient.invalidateQueries({ queryKey: ['radio-channels', eventId] });
+      toast.success('Assignment deleted');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const channel = channels.find((c) => c.id === assignment.radioChannelId);
+
+  if (editing) {
+    return (
+      <tr className="border-b">
+        <td className="py-3 px-4 text-sm">{assignment.squadName}</td>
+        <td className="py-3 px-4 text-sm">{assignment.channelName}</td>
+        <td className="py-3 px-4">
+          <div className="space-y-1">
+            <Input
+              aria-label="Primary frequency (MHz)"
+              value={freqValue}
+              onChange={(e) => handleFreqChange(e.target.value)}
+              placeholder="e.g. 36.500"
+              className="h-8 w-32"
+              type="number"
+              step="0.025"
+              min={channel ? SCOPE_INFO[channel.scope].min : 30}
+              max={channel ? SCOPE_INFO[channel.scope].max : 400}
+              autoFocus
+            />
+            {freqError && (
+              <p className="text-xs text-red-600" role="alert">{freqError}</p>
+            )}
+          </div>
+        </td>
+        <td className="py-3 px-4">
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => updateMutation.mutate()}
+              disabled={updateMutation.isPending || !!freqError || !freqValue}
+              aria-label="Save assignment"
+            >
+              <Check className="h-4 w-4 text-green-600" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => { setEditing(false); setFreqValue(assignment.primaryFrequency.toString()); setFreqError(null); }}
+              aria-label="Cancel edit"
+            >
+              <X className="h-4 w-4 text-red-600" />
+            </Button>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr className="border-b hover:bg-muted/50">
+      <td className="py-3 px-4 text-sm font-medium">{assignment.squadName}</td>
+      <td className="py-3 px-4 text-sm">
+        {assignment.channelName}
+        <span className="ml-2 text-xs text-muted-foreground">{assignment.channelScope}</span>
+      </td>
+      <td className="py-3 px-4 text-sm font-mono">{assignment.primaryFrequency.toFixed(3)} MHz</td>
+      <td className="py-3 px-4">
+        {isCommander && (
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setEditing(true)}
+              aria-label={`Edit assignment for ${assignment.squadName}`}
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => deleteMutation.mutate()}
+              disabled={deleteMutation.isPending}
+              aria-label={`Delete assignment for ${assignment.squadName}`}
+            >
+              <Trash2 className="h-4 w-4 text-red-500" />
+            </Button>
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ── Create assignment form (AC-01, AC-02, AC-03, AC-10) ───────────────────────
+
+interface CreateAssignmentFormProps {
+  eventId: string;
+  channels: RadioChannelListDto[];
+}
+
+interface FlatSquad {
+  id: string;
+  name: string;
+  platoonName: string;
+}
+
+function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) {
+  const queryClient = useQueryClient();
+
+  const [open, setOpen] = useState(false);
+  const [channelId, setChannelId] = useState('');
+  const [squadId, setSquadId] = useState('');
+  const [freqValue, setFreqValue] = useState('');
+  const [freqError, setFreqError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Load roster to get squad list (AC-01)
+  const { data: roster } = useQuery({
+    queryKey: ['roster', eventId],
+    queryFn: () => api.getRoster(eventId),
+    enabled: open,
+  });
+
+  // Flatten squads from platoon hierarchy
+  const squads: FlatSquad[] = roster
+    ? roster.platoons.flatMap((p) =>
+        p.squads.map((s) => ({ id: s.id, name: s.name, platoonName: p.name }))
+      )
+    : [];
+
+  const selectedChannel = channels.find((c) => c.id === channelId);
+
+  // Real-time frequency validation (AC-10)
+  const handleFreqChange = (val: string) => {
+    setFreqValue(val);
+    if (selectedChannel) {
+      setFreqError(validateFrequency(val, selectedChannel.scope));
+    } else {
+      setFreqError(null);
+    }
+  };
+
+  // Re-validate when channel scope changes
+  const handleChannelChange = (id: string) => {
+    setChannelId(id);
+    const ch = channels.find((c) => c.id === id);
+    if (ch && freqValue) {
+      setFreqError(validateFrequency(freqValue, ch.scope));
+    }
+  };
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      api.createChannelAssignment(eventId, {
+        radioChannelId: channelId,
+        squadId,
+        primaryFrequency: parseFloat(freqValue),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['channel-assignments', eventId] });
+      void queryClient.invalidateQueries({ queryKey: ['radio-channels', eventId] });
+      setOpen(false);
+      setChannelId('');
+      setSquadId('');
+      setFreqValue('');
+      setFreqError(null);
+      setFormError(null);
+      toast.success('Assignment created');
+    },
+    onError: (err: Error & { status?: number }) => {
+      setFormError(err.message);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!channelId) { setFormError('Select a channel.'); return; }
+    if (!squadId) { setFormError('Select a unit.'); return; }
+    const err = selectedChannel ? validateFrequency(freqValue, selectedChannel.scope) : 'Select a channel first.';
+    if (err) { setFreqError(err); return; }
+    setFormError(null);
+    createMutation.mutate();
+  };
+
+  if (!open) {
+    return (
+      <Button onClick={() => setOpen(true)} size="sm" variant="outline">
+        <Plus className="h-4 w-4 mr-1" />
+        Assign Frequency
+      </Button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border rounded-lg p-4 bg-muted/30 space-y-4">
+      <h3 className="font-semibold text-sm">Assign Frequency to Unit</h3>
+
+      {/* AC-02: Channel selector */}
+      <div className="space-y-2">
+        <label htmlFor="assign-channel" className="text-sm font-medium">
+          Channel <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="assign-channel"
+          aria-label="Select channel"
+          value={channelId}
+          onChange={(e) => handleChannelChange(e.target.value)}
+          className="h-9 w-full max-w-sm rounded border border-input bg-background px-3 text-sm"
+        >
+          <option value="">Select a channel…</option>
+          {channels.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name} ({c.scope} — {SCOPE_INFO[c.scope].range})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* AC-01: Unit (squad) selector */}
+      <div className="space-y-2">
+        <label htmlFor="assign-squad" className="text-sm font-medium">
+          Unit <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="assign-squad"
+          aria-label="Select unit"
+          value={squadId}
+          onChange={(e) => setSquadId(e.target.value)}
+          className="h-9 w-full max-w-sm rounded border border-input bg-background px-3 text-sm"
+        >
+          <option value="">Select a unit…</option>
+          {squads.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name} ({s.platoonName})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* AC-03: Primary frequency input (MHz) with AC-10 real-time validation */}
+      <div className="space-y-2">
+        <label htmlFor="assign-freq" className="text-sm font-medium">
+          Primary frequency (MHz) <span className="text-red-500">*</span>
+        </label>
+        <Input
+          id="assign-freq"
+          aria-label="Primary frequency (MHz)"
+          value={freqValue}
+          onChange={(e) => handleFreqChange(e.target.value)}
+          placeholder={
+            selectedChannel
+              ? `e.g. ${selectedChannel.scope === 'VHF' ? '36.500' : '225.025'}`
+              : 'Select a channel first'
+          }
+          type="number"
+          step="0.025"
+          min={selectedChannel ? SCOPE_INFO[selectedChannel.scope].min : undefined}
+          max={selectedChannel ? SCOPE_INFO[selectedChannel.scope].max : undefined}
+          className="max-w-xs"
+          disabled={!channelId}
+        />
+        {freqError && (
+          <p className="text-xs text-red-600" role="alert">{freqError}</p>
+        )}
+        {selectedChannel && !freqError && freqValue && (
+          <p className="text-xs text-green-600">Valid {selectedChannel.scope} frequency</p>
+        )}
+        {selectedChannel && (
+          <p className="text-xs text-muted-foreground">
+            {selectedChannel.scope} range: {SCOPE_INFO[selectedChannel.scope].range}, 25 kHz spacing
+          </p>
+        )}
+      </div>
+
+      {formError && (
+        <p className="text-sm text-red-600" role="alert">{formError}</p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          type="submit"
+          size="sm"
+          disabled={createMutation.isPending || !channelId || !squadId || !!freqError || !freqValue}
+        >
+          {createMutation.isPending ? 'Saving…' : 'Save Assignment'}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setOpen(false);
+            setChannelId('');
+            setSquadId('');
+            setFreqValue('');
+            setFreqError(null);
+            setFormError(null);
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// ── Assignments section (AC-08: list view) ────────────────────────────────────
+
+interface AssignmentsSectionProps {
+  eventId: string;
+  channels: RadioChannelListDto[];
+  isCommander: boolean;
+}
+
+function AssignmentsSection({ eventId, channels, isCommander }: AssignmentsSectionProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['channel-assignments', eventId],
+    queryFn: () => api.getChannelAssignments(eventId),
+    enabled: !!eventId,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Frequency Assignments</h2>
+        {isCommander && channels.length > 0 && (
+          <CreateAssignmentForm eventId={eventId} channels={channels} />
+        )}
+      </div>
+
+      {isLoading && <div className="text-sm text-muted-foreground">Loading assignments…</div>}
+      {error && <div className="text-sm text-red-600">Failed to load assignments.</div>}
+
+      {data && data.items.length === 0 && (
+        <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground text-sm">
+          No frequency assignments yet.
+          {isCommander && channels.length > 0 && (
+            <span> Click "Assign Frequency" to get started.</span>
+          )}
+        </div>
+      )}
+
+      {data && data.items.length > 0 && (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="text-left py-2 px-4 font-medium">Unit</th>
+                <th className="text-left py-2 px-4 font-medium">Channel</th>
+                <th className="text-left py-2 px-4 font-medium">Primary Frequency</th>
+                <th className="py-2 px-4" />
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((assignment) => (
+                <AssignmentRow
+                  key={assignment.id}
+                  assignment={assignment}
+                  channels={channels}
+                  isCommander={isCommander}
+                  eventId={eventId}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Page component ─────────────────────────────────────────────────────────────
 
 export function RadioChannelsPage() {
@@ -283,7 +715,7 @@ export function RadioChannelsPage() {
   if (error) return <div className="p-6 text-red-600">Failed to load channels.</div>;
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-6 space-y-8">
       {/* Breadcrumb */}
       <nav className="text-sm text-muted-foreground flex items-center gap-1">
         <Link to="/events" className="hover:underline">Events</Link>
@@ -332,6 +764,15 @@ export function RadioChannelsPage() {
             </tbody>
           </table>
         </div>
+      )}
+
+      {/* Frequency assignments section (AC-08) */}
+      {id && (
+        <AssignmentsSection
+          eventId={id}
+          channels={channels ?? []}
+          isCommander={isCommander}
+        />
       )}
     </div>
   );

--- a/web/src/pages/events/RadioChannelsPage.tsx
+++ b/web/src/pages/events/RadioChannelsPage.tsx
@@ -353,7 +353,11 @@ function AssignmentRow({ assignment, channels, isCommander, eventId }: Assignmen
       toast.success('Assignment updated');
     },
     onError: (err: Error & { status?: number }) => {
-      setFreqError(err.message);
+      if (err.status === 409) {
+        setFreqError(`Frequency conflict: ${err.message}`);
+      } else {
+        setFreqError(err.message);
+      }
     },
   });
 
@@ -614,7 +618,11 @@ function CreateAssignmentForm({ eventId, channels }: CreateAssignmentFormProps) 
       toast.success('Assignment created');
     },
     onError: (err: Error & { status?: number }) => {
-      setFormError(err.message);
+      if (err.status === 409) {
+        setFormError(`Frequency conflict: ${err.message}`);
+      } else {
+        setFormError(err.message);
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
- Implements Story 4 (issue #900) — operation-scoped frequency conflict detection and advisory warning
- Backend (.NET 10): `DetectFrequencyConflictsAsync` checks primary + alternate frequencies; advisory mode returns 409 with conflict details; override flag allows planner to proceed; `HasConflict` persisted on assignment record; EF migration adds `HasConflict` column; audit log emitted on every create/update/delete; `GET .../conflicts` endpoint returns full conflict summary
- Frontend (React 19): `ConflictConfirmDialog` intercepts 409 responses, presents OK/Cancel advisory; re-submits with `overrideConflict=true`; conflict badges shown in assignment list

## Acceptance Criteria Coverage

| AC | Description | Status |
|----|-------------|--------|
| AC-01 | Check frequency on assignment (same operation) | ✅ |
| AC-02 | Both primary + alternate checked | ✅ |
| AC-03 | Operation-scoped only (channel = operation) | ✅ |
| AC-04 | Advisory mode: 409 → dialog → override | ✅ |
| AC-05 | HasConflict persisted on record + migration | ✅ |
| AC-06 | Audit log entry on create/update/delete | ✅ |
| AC-07 | GET /conflicts summary endpoint | ✅ |

## Test Plan
- [ ] `CreateAssignment_DuplicatePrimaryFrequency_Returns409` — existing test
- [ ] `CreateAssignment_PrimaryConflictsWithExistingAlternate_Returns409` — existing test
- [ ] `CreateAssignment_AlternateConflictsWithExistingPrimary_Returns409` — existing test
- [ ] `UpdateAssignment_ConflictsWithOtherUnit_Returns409` — existing test
- [ ] `UpdateAssignment_SameFrequency_NoConflictWithSelf_Returns200` — existing test
- [ ] `CreateAssignment_SameFrequencyDifferentChannel_Returns201` — existing test (AC-03)
- [ ] `CreateAssignment_WithOverrideConflict_Returns201WithHasConflictTrue` — new (AC-04 override)
- [ ] `CreateAssignment_NoConflict_ReturnsHasConflictFalse` — new (AC-05 clean state)
- [ ] `GetConflicts_ReturnsConflictSummaryWithConflictingUnits` — new (AC-07)

**Note AC-04:** Mode is structurally decoupled — switching from advisory to hard-block requires only changing one condition in `ChannelAssignmentService`, no refactoring needed when stakeholder answers Q2.

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)